### PR TITLE
Stop re-run, organize artifacts, rm app-name hard-codes

### DIFF
--- a/.github/workflows/buildMaster.yml
+++ b/.github/workflows/buildMaster.yml
@@ -41,7 +41,8 @@ jobs:
       - name: No re-runs please
         run: |
          if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
-            echo "No re-runs. They can lead to a situation where code older than HEAD isn't compatible. Start a new workflow run instead."
+            echo "No re-runs. They use the commit SHA and git ref of the original event that triggered the workflow run. However, that does not extend to client and resource repos which may expect a more recent panksomia-web."
+            echo "Start a new workflow run instead."
             exit 1
           else
             echo "NOT a re-run"

--- a/.github/workflows/buildMaster.yml
+++ b/.github/workflows/buildMaster.yml
@@ -37,6 +37,17 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
+      # Turn off re-runs
+      - name: No re-runs please
+        run: |
+         if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+            echo "No re-runs. They can lead to a situation where code older than HEAD isn't compatible. Start a new workflow run instead."
+            exit 1
+          else
+            echo "NOT a re-run"
+          fi
+
+      # Check build status
       - name: Check build status
         run: |
           if [[ "${{ needs.build-macos-intel.result }}" != "success" || 

--- a/.github/workflows/linux-build-steps.yml
+++ b/.github/workflows/linux-build-steps.yml
@@ -23,7 +23,8 @@ jobs:
       - name: No re-runs please
         run: |
          if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
-            echo "No re-runs. They can lead to a situation where code older than HEAD isn't compatible. Start a new workflow run instead."
+            echo "No re-runs. They use the commit SHA and git ref of the original event that triggered the workflow run. However, that does not extend to client and resource repos which may expect a more recent panksomia-web."
+            echo "Start a new workflow run instead."
             exit 1
           else
             echo "NOT a re-run"

--- a/.github/workflows/linux-build-steps.yml
+++ b/.github/workflows/linux-build-steps.yml
@@ -83,3 +83,5 @@ jobs:
         with:
           name: ${{ env.TGZ_NAME }}
           path: ./releases/linux/${{ env.TGZ_NAME }}
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/linux-build-steps.yml
+++ b/.github/workflows/linux-build-steps.yml
@@ -19,6 +19,16 @@ jobs:
       tgz-name: ${{ steps.get-tgz-name.outputs.tgz-name }}
     
     steps:
+      # Turn off re-runs
+      - name: No re-runs please
+        run: |
+         if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+            echo "No re-runs. They can lead to a situation where code older than HEAD isn't compatible. Start a new workflow run instead."
+            exit 1
+          else
+            echo "NOT a re-run"
+          fi
+
       # Rust
       - name: Set up Rust
         id: set-up-rust

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -38,6 +38,17 @@ jobs:
       pkg-name-intel: ${{ steps.get-installer-names.outputs.pkg-name-intel }}
     
     steps:
+      # Turn off re-runs
+      - name: No re-runs please
+        run: |
+         if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+            echo "No re-runs. They can lead to a situation where code older than HEAD isn't compatible. Start a new workflow run instead."
+            exit 1
+          else
+            echo "NOT a re-run"
+          fi
+
+      # Add delay before build
       - name: Add delay before build
         run: sleep ${{ inputs.delay_seconds }}
 

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -173,14 +173,14 @@ jobs:
         run: |
           echo "Setup a README named for arm64 and intel64 artifact"
           echo ${{github.event.pull_request.head.repo.full_name}}
-          cp ./macos/build/README.txt ./macos/build/MacOS-PKG-README-arm64-and-intel64.txt
+          cp ./macos/build/README.txt ./macos/build/macos-installer-readme-arm64-and-intel64.txt
 
       - name: Upload README for arm64 and intel64 artifact
         if: env.PKG_NAME_ARM != '' # only upload once
         uses: actions/upload-artifact@v4
         with:
-          name: MacOS-PKG-README-arm64-and-intel64.txt
-          path: ./macos/build/MacOS-PKG-README-arm64-and-intel64.txt
+          name: macos-installer-readme-arm64-and-intel64.txt
+          path: ./macos/build/macos-installer-readme-arm64-and-intel64.txt
           if-no-files-found: error
           retention-days: 90
 

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -42,7 +42,8 @@ jobs:
       - name: No re-runs please
         run: |
          if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
-            echo "No re-runs. They can lead to a situation where code older than HEAD isn't compatible. Start a new workflow run instead."
+            echo "No re-runs. They use the commit SHA and git ref of the original event that triggered the workflow run. However, that does not extend to client and resource repos which may expect a more recent panksomia-web."
+            echo "Start a new workflow run instead."
             exit 1
           else
             echo "NOT a re-run"

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -172,6 +172,7 @@ jobs:
       - name: Setup a README named for arm64 and intel64 artifact
         run: |
           echo "Setup a README named for arm64 and intel64 artifact"
+          echo ${{github.event.pull_request.head.repo.full_name}}
           cp ./macos/build/README.txt ./macos/build/MacOS-PKG-README-arm64-and-intel64.txt
 
       - name: Upload README for arm64 and intel64 artifact

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -172,15 +172,14 @@ jobs:
       - name: Setup a README named for arm64 and intel64 artifact
         run: |
           echo "Setup a README named for arm64 and intel64 artifact"
-          echo ${{github.event.pull_request.head.repo.full_name}}
-          cp ./macos/build/README.txt ./macos/build/macos-installer-readme-arm64-and-intel64.txt
+          cp ./macos/build/README.txt ./macos/build/${{github.event.pull_request.head.repo.full_name}}-macos-installer-readme-arm64-and-intel64.txt
 
       - name: Upload README for arm64 and intel64 artifact
         if: env.PKG_NAME_ARM != '' # only upload once
         uses: actions/upload-artifact@v4
         with:
-          name: macos-installer-readme-arm64-and-intel64.txt
-          path: ./macos/build/macos-installer-readme-arm64-and-intel64.txt
+          name: ${{github.event.pull_request.head.repo.full_name}}-macos-installer-readme-arm64-and-intel64.txt
+          path: ./macos/build/${{github.event.pull_request.head.repo.full_name}}-macos-installer-readme-arm64-and-intel64.txt
           if-no-files-found: error
           retention-days: 90
 

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -113,6 +113,8 @@ jobs:
         with:
           name: ${{ env.ZIP_NAME }}
           path: ./releases/macos/${{ env.ZIP_NAME }}
+          if-no-files-found: error
+          retention-days: 90
 
       - name: Run makeAllInstalls.sh
         working-directory: ./macos/install
@@ -155,6 +157,8 @@ jobs:
         with:
           name: ${{ env.PKG_NAME_ARM }}
           path: ./macos/release/arm64/${{ env.PKG_NAME_ARM }}
+          if-no-files-found: error
+          retention-days: 90
 
       - name: Upload intel64 artifacts
         if: env.PKG_NAME_INTEL != ''
@@ -162,6 +166,8 @@ jobs:
         with:
           name: ${{ env.PKG_NAME_INTEL }}
           path: ./macos/release/intel64/${{ env.PKG_NAME_INTEL }}
+          if-no-files-found: error
+          retention-days: 90
 
       - name: Setup a README named for arm64 and intel64 artifact
         run: |
@@ -174,6 +180,8 @@ jobs:
         with:
           name: MacOS-PKG-README-arm64-and-intel64.txt
           path: ./macos/build/MacOS-PKG-README-arm64-and-intel64.txt
+          if-no-files-found: error
+          retention-days: 90
 
       # build electronite installs
       - name: Run makeAllInstallsElectronite.sh
@@ -215,6 +223,8 @@ jobs:
         with:
           name: ${{ env.PKG_NAME_ARM }}
           path: ./releases/macos/${{ env.PKG_NAME_ARM }}
+          if-no-files-found: error
+          retention-days: 90
 
       - name: Upload electronite intel64 artifacts
         if: env.PKG_NAME_INTEL != ''
@@ -222,3 +232,5 @@ jobs:
         with:
           name: ${{ env.PKG_NAME_INTEL }}
           path: ./releases/macos/${{ env.PKG_NAME_INTEL }}
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -172,14 +172,14 @@ jobs:
       - name: Setup a README named for arm64 and intel64 artifact
         run: |
           echo "Setup a README named for arm64 and intel64 artifact"
-          cp ./macos/build/README.txt ./macos/build/${{github.event.pull_request.head.repo.full_name}}-macos-installer-readme-arm64-and-intel64.txt
+          cp ./macos/build/README.txt ./macos/build/${{ github.event.repository.name }}-macos-installer-readme-arm64-and-intel64.txt
 
       - name: Upload README for arm64 and intel64 artifact
         if: env.PKG_NAME_ARM != '' # only upload once
         uses: actions/upload-artifact@v4
         with:
-          name: ${{github.event.pull_request.head.repo.full_name}}-macos-installer-readme-arm64-and-intel64.txt
-          path: ./macos/build/${{github.event.pull_request.head.repo.full_name}}-macos-installer-readme-arm64-and-intel64.txt
+          name: ${{ github.event.repository.name }}-macos-installer-readme-arm64-and-intel64.txt
+          path: ./macos/build/${{ github.event.repository.name }}-macos-installer-readme-arm64-and-intel64.txt
           if-no-files-found: error
           retention-days: 90
 

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -27,6 +27,16 @@ jobs:
       electronite-exe-name: ${{ steps.get-electronite-exe-name.outputs.electronite-exe-name }}
     
     steps:
+      # Turn off re-runs
+      - name: No re-runs please
+        run: |
+         if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+            echo "No re-runs. They can lead to a situation where code older than HEAD isn't compatible. Start a new workflow run instead."
+            exit 1
+          else
+            echo "NOT a re-run"
+          fi
+
       # Install Inno Setup
       - name: Install Inno Setup
         run: choco install innosetup

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -31,7 +31,8 @@ jobs:
       - name: No re-runs please
         run: |
          if ( ${{ github.run_attempt }} -gt 1 ) {
-            echo "No re-runs. They can lead to a situation where code older than HEAD isn't compatible. Start a new workflow run instead."
+            echo "No re-runs. They use the commit SHA and git ref of the original event that triggered the workflow run. However, that does not extend to client and resource repos which may expect a more recent panksomia-web."
+            echo "Start a new workflow run instead."
             exit 1
           } else {
             echo "NOT a re-run"

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -30,7 +30,7 @@ jobs:
       # Turn off re-runs
       - name: No re-runs please
         run: |
-         if ( $GITHUB_RUN_ATTEMPT -gt 1 ) {
+         if ( ${{ github.run_attempt }} -gt 1 ) {
             echo "No re-runs. They can lead to a situation where code older than HEAD isn't compatible. Start a new workflow run instead."
             exit 1
           } else {

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -30,13 +30,10 @@ jobs:
       # Turn off re-runs
       - name: No re-runs please
         run: |
-         if ( "$GITHUB_RUN_ATTEMPT" -gt 1 )
-         {
+         if ( $GITHUB_RUN_ATTEMPT -gt 1 ) {
             echo "No re-runs. They can lead to a situation where code older than HEAD isn't compatible. Start a new workflow run instead."
             exit 1
-          }
-          else
-          {
+          } else {
             echo "NOT a re-run"
           }
 

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -30,12 +30,15 @@ jobs:
       # Turn off re-runs
       - name: No re-runs please
         run: |
-         if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+         if ( "$GITHUB_RUN_ATTEMPT" -gt 1 )
+         {
             echo "No re-runs. They can lead to a situation where code older than HEAD isn't compatible. Start a new workflow run instead."
             exit 1
+          }
           else
+          {
             echo "NOT a re-run"
-          fi
+          }
 
       # Install Inno Setup
       - name: Install Inno Setup

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -123,6 +123,8 @@ jobs:
         with:
           name: ${{ env.ZIP_NAME }}
           path: .\releases\windows\${{ env.ZIP_NAME }}
+          if-no-files-found: error
+          retention-days: 90
 
       # Get workspace location and repo name
       - name: Show workspace and repo name
@@ -154,6 +156,8 @@ jobs:
         with:
           name: ${{ env.EXE_NAME }}
           path: .\releases\windows\${{ env.EXE_NAME }}
+          if-no-files-found: error
+          retention-days: 90
 
       # Build electronite
       - name: Run makeAllInstallsElectronite.ps1
@@ -175,3 +179,5 @@ jobs:
         with:
           name: ${{ env.ELECTRONITE_EXE_NAME }}
           path: .\releases\windows\intel64\${{ env.ELECTRONITE_EXE_NAME }}
+          if-no-files-found: error
+          retention-days: 90

--- a/macos/buildResources/appLauncherElectron.sh
+++ b/macos/buildResources/appLauncherElectron.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo "========================"
-echo "Liminal starting up:"
+echo "Starting up:"
 echo "Current directory:"
 pwd
 

--- a/macos/install/getRelease.sh
+++ b/macos/install/getRelease.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 # Synopsis:
-#   getLiminalRelease.sh <downloadUrl> <arch>
+#   getRelease.sh <downloadUrl> <arch>
 #
 # Description:
-#   Downloads a Liminal release package from the specified URL for a given architecture.
+#   Downloads a release package from the specified URL for a given architecture.
 #   The script extracts the version from the filename, creates necessary directories,
 #   and downloads the package to a temporary location.
 #

--- a/macos/install/makeAllInstallsElectronite.sh
+++ b/macos/install/makeAllInstallsElectronite.sh
@@ -4,9 +4,9 @@
 #   makeAllInstallsElectronite.sh
 #
 # Description:
-#   This script automates the build process for Liminal application on macOS,
+#   This script automates the build process for the application on macOS,
 #   creating installation packages for both Intel (x64) and ARM64 architectures.
-#   It downloads the required Electron and Liminal releases, and processes them
+#   It downloads the required Electron and zip releases, and processes them
 #   into installable packages.
 #
 # Parameters:
@@ -64,10 +64,10 @@ for ARCH in "intel64" "arm64"; do
     echo "Building for architecture: $ARCH"
   
     downloadElectronUrl="$ElectronIntel64"
-    expectedLiminalZip="*-intel64-*.zip"
+    expectedZip="*-intel64-*.zip"
     if [ "$ARCH" = "arm64" ]; then
         downloadElectronUrl="$ElectronArm64"
-        expectedLiminalZip="*-arm64-*.zip"
+        expectedZip="*-arm64-*.zip"
     fi
 
     ./getElectronRelease.sh  $downloadElectronUrl $ARCH
@@ -78,14 +78,14 @@ for ARCH in "intel64" "arm64"; do
         exit 1
     fi
     
-    # Check if Liminal zip file exists
-    zipFile=$(ls -1 ../../releases/macos/$expectedLiminalZip | head -n1)
+    # Check if zip file exists
+    zipFile=$(ls -1 ../../releases/macos/$expectedZip | head -n1)
     if [ -z "$zipFile" ]; then
-        echo "Error: Liminal zip file not found in ../../releases/macos/"
+        echo "Error: zip file not found in ../../releases/macos/"
         exit 1
     fi
     
-    # unzip the liminal install files and create mac install package
+    # unzip the install files and create mac install package
     ./makeInstallFromZipElectronite.sh  $zipFile ../temp/release $ARCH
     
     if [ $? -ne 0 ]; then

--- a/macos/install/makeInstall.sh
+++ b/macos/install/makeInstall.sh
@@ -29,7 +29,7 @@ export FILE_APP_NAME="$FILE_APP_NAME"
 arch="$1"
 
 # There shouldn't be a need to rm the file from the gh actions runner as it is new every time...
-rm -f ../../releases/macos/${FILE_APP_NAME}-installer-macos-${arch}-*.pkg
+rm -f ../../releases/macos/${FILE_APP_NAME}-macos-installer-${arch}-*.pkg
 
 cd ../build || exit 1
 
@@ -98,7 +98,7 @@ pkgbuild \
   --identifier "$APP_NAME" \
   --version "$APP_VERSION" \
   --install-location /Applications \
-  ./build/${FILE_APP_NAME}-installer-macos-${arch}-${APP_VERSION}.pkg
+  ./build/${FILE_APP_NAME}-macos-installer-${arch}-${APP_VERSION}.pkg
 
 # copy to releases folder
-cp ./build/${FILE_APP_NAME}-installer-macos-${arch}-${APP_VERSION}.pkg ../releases/macos/
+cp ./build/${FILE_APP_NAME}-macos-installer-${arch}-${APP_VERSION}.pkg ../releases/macos/

--- a/macos/install/makeInstallElectronite.sh
+++ b/macos/install/makeInstallElectronite.sh
@@ -51,7 +51,7 @@ fi
 
 arch="$1"
 
-PKG_NAME="${FILE_APP_NAME}-installer-macos-standalone-${arch}-${APP_VERSION}.pkg"
+PKG_NAME="${FILE_APP_NAME}-macos-installer-standalone-${arch}-${APP_VERSION}.pkg"
 rm -f ./build/${PKG_NAME}
 rm -f ../releases/macos/${PKG_NAME}
 

--- a/macos/install/makeInstallElectronite.sh
+++ b/macos/install/makeInstallElectronite.sh
@@ -3,7 +3,7 @@
 # MacOS Installation Package Builder Script
 #
 # Synopsis:
-#   Creates a macOS installation package (.pkg) for the Liminal application
+#   Creates a macOS installation package (.pkg) for the application
 #   based on provided architecture (arm64 or intel64) and APP_VERSION.
 #
 # Description:
@@ -29,7 +29,7 @@
 #   1 : Failure (Invalid/missing parameters or execution error)
 #
 # Output:
-#   Creates installer package at: ../releases/macos/liminal_installer_<arch>_<version>.pkg
+#   Creates installer package at: ../releases/macos/<app-name>_installer_<arch>_<version>.pkg
 
 # Check if APP_NAME environment variable is set
 if [ -z "$APP_NAME" ]; then

--- a/macos/install/makeInstallFromBuild.sh
+++ b/macos/install/makeInstallFromBuild.sh
@@ -41,6 +41,6 @@ echo "Processing '$filename'"
 
 rm -rf "$destination"
 mkdir -p "$destination"
-cp ../../releases/macos/${FILE_APP_NAME}-installer-macos-${arch}-*.pkg "$destination"
+cp ../../releases/macos/${FILE_APP_NAME}-macos-installer-${arch}-*.pkg "$destination"
 echo "Files at $destination"
 ls -als "$destination/"

--- a/macos/install/makeInstallFromZipElectronite.sh
+++ b/macos/install/makeInstallFromZipElectronite.sh
@@ -24,7 +24,7 @@
 #   0 - Success
 #   1 - Error (invalid parameters or processing failure)
 #   
-# Generated files will be placed in <destination-folder>/<arch>/liminal_installer_*.pkg
+# Generated files will be placed in <destination-folder>/<arch>/<app-name>_installer_*.pkg
 
 # Check if filename and destination are provided as an argument
 if [ -z "$3" ]; then

--- a/windows/buildResources/appLauncherElectron.bat
+++ b/windows/buildResources/appLauncherElectron.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 echo ========================
-echo Liminal starting up:
+echo Starting up:
 echo Current directory:
 cd
 
@@ -21,8 +21,6 @@ if exist "%SCRIPT_DIR%\..\bin\server.exe" (
     set "BASE=.."
 ) else if exist ".\Contents\bin\server.exe" (
     set "BASE=.\Contents"
-) else if exist "C:\Program Files\Liminal\bin\server.exe" (
-    set "BASE=C:\Program Files\Liminal"
 ) else (
     echo Error: server.exe not found in expected locations
     exit /b 1

--- a/windows/install/getVersion.ps1
+++ b/windows/install/getVersion.ps1
@@ -3,7 +3,7 @@
     Extracts version number from a filename and sets it as APP_VERSION environment variable.
 
 .DESCRIPTION
-    This PowerShell script is part of the Liminal Windows installation process.
+    This PowerShell script is part of the Windows installation process.
     It extracts a version number from an input filename using regex pattern matching
     and sets it as an environment variable. The version number must be in the format
     'vX.Y.Z' where X, Y, and Z are numeric values. This script is used by the Inno

--- a/windows/install/makeAllInstallsElectronite.ps1
+++ b/windows/install/makeAllInstallsElectronite.ps1
@@ -1,10 +1,10 @@
 <#
 .SYNOPSIS
-    Creates Windows installation packages for Liminal application.
+    Creates Windows installation packages for the application.
 
 .DESCRIPTION
-    This script automates the build process for Liminal Windows installers:
-    - Downloads Electron and Liminal releases for specified architectures
+    This script automates the build process for Windows installers:
+    - Downloads Electron and zip releases for specified architectures
     - Processes and packages the files
     - Creates installation packages for each supported architecture
     - Currently supports Intel64 architecture (ARM64 support is commented out)
@@ -12,8 +12,7 @@
 .NOTES
     Requires PowerShell and depends on:
     - getElectronRelease.ps1
-    - getLiminalRelease.ps1
-    - makeInstallFromZip.ps1F
+    - makeInstallElectroniteFromZip.ps1
 #>
 
 # get environment variables from app_config.env
@@ -45,11 +44,11 @@ foreach ($ARCH in @("intel64")) {
 
     # Set download URLs based on architecture
     $downloadElectronUrl = $ElectronIntel64
-    $expectedLiminalZip = "*-windows-*.zip"
+    $expectedZip = "*-windows-*.zip"
 
     if ($ARCH -eq "arm64") {
         $downloadElectronUrl = $ElectronArm64
-        $expectedLiminalZip = "*-windows-*.zip" # TODO need to set for arm
+        $expectedZip = "*-windows-*.zip" # TODO need to set for arm
     }
 
     # Get Electron release
@@ -60,15 +59,15 @@ foreach ($ARCH in @("intel64")) {
         exit 1
     }
 
-    # verify liminal zip
-    If (-Not (Test-Path ..\..\releases\windows\$expectedLiminalZip)) {
+    # verify zip
+    If (-Not (Test-Path ..\..\releases\windows\$expectedZip)) {
         echo "Error: Missing windows .zip release"
         exit 1
     }
 
     # Make install from zip
     Write-Host "Creating install package..."
-    $zipPath = Resolve-Path "..\..\releases\windows\$expectedLiminalZip"
+    $zipPath = Resolve-Path "..\..\releases\windows\$expectedZip"
     $installResult = & "$PSScriptRoot\makeInstallElectroniteFromZip.ps1" -zipPath $zipPath -destinationFolder "..\temp\release" -arch $ARCH
     if ($LASTEXITCODE -ne 0) {
         Write-Host "Error: Build failed for architecture $ARCH"

--- a/windows/install/makeInstall.iss
+++ b/windows/install/makeInstall.iss
@@ -3,7 +3,7 @@
    AppVersion={#GetEnv('APP_VERSION')}
    DefaultDirName={commonpf}\{#GetEnv('APP_NAME')}
    DefaultGroupName={#GetEnv('APP_NAME')}
-   OutputBaseFilename={#GetEnv('FILE_APP_NAME')}-setup-{#GetEnv('APP_VERSION')}
+   OutputBaseFilename={#GetEnv('FILE_APP_NAME')}-windows-setup-{#GetEnv('APP_VERSION')}
    Compression=lzma
    SolidCompression=yes
 

--- a/windows/install/makeInstallElectronite.iss
+++ b/windows/install/makeInstallElectronite.iss
@@ -8,7 +8,7 @@ Compression=lzma
 SolidCompression=yes
 
 [Files]
-Source: "..\temp\project\payload\Liminal\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
+Source: "..\temp\project\payload\{#GetEnv('FILE_APP_NAME')}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 
 [Icons]
 Name: "{group}\{#GetEnv('APP_NAME')}"; Filename: "{app}\electron\electron.exe"; Parameters: """{app}\electron"""

--- a/windows/install/makeInstallElectronite.iss
+++ b/windows/install/makeInstallElectronite.iss
@@ -3,7 +3,7 @@ AppName={#GetEnv('APP_NAME')}
 AppVersion={#GetEnv('APP_VERSION')}
 DefaultDirName={commonpf}\{#GetEnv('APP_NAME')}
 DefaultGroupName={#GetEnv('APP_NAME')}
-OutputBaseFilename={#GetEnv('FILE_APP_NAME')}-standalone-setup-{#GetEnv('APP_VERSION')}
+OutputBaseFilename={#GetEnv('FILE_APP_NAME')}-windows-setup-standalone-{#GetEnv('APP_VERSION')}
 Compression=lzma
 SolidCompression=yes
 

--- a/windows/install/makeInstallElectronite.iss
+++ b/windows/install/makeInstallElectronite.iss
@@ -8,7 +8,7 @@ Compression=lzma
 SolidCompression=yes
 
 [Files]
-Source: "..\temp\project\payload\{#GetEnv('FILE_APP_NAME')}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
+Source: "..\temp\project\payload\app\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 
 [Icons]
 Name: "{group}\{#GetEnv('APP_NAME')}"; Filename: "{app}\electron\electron.exe"; Parameters: """{app}\electron"""

--- a/windows/install/makeInstallElectronite.ps1
+++ b/windows/install/makeInstallElectronite.ps1
@@ -68,7 +68,7 @@ try {
     # Clean up and create project directories
     Remove-Item -Path "..\temp\project" -Recurse -Force -ErrorAction SilentlyContinue
     $projectPath = "..\temp\project"
-    $payloadPath = Join-Path $projectPath "payload\"$fileAppName
+    $payloadPath = Join-Path $projectPath "payload\app"
 
     New-Item -ItemType Directory -Force -Path $payloadPath | Out-Null
 

--- a/windows/install/makeInstallElectronite.ps1
+++ b/windows/install/makeInstallElectronite.ps1
@@ -11,7 +11,7 @@
 
 .PREREQUISITES
     - Inno Setup 6 must be installed at "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
-    - APP_VERSION environment variable must be set (e.g., $env:APP_VERSION = "0.2.6")
+    - APP_VERSION environment variable must be set in app_config.env
 
 .OUTPUTS
     Creates an installer at releases\windows\$arch\<app-name>_installer_*.exe
@@ -68,7 +68,7 @@ try {
     # Clean up and create project directories
     Remove-Item -Path "..\temp\project" -Recurse -Force -ErrorAction SilentlyContinue
     $projectPath = "..\temp\project"
-    $payloadPath = Join-Path $projectPath "payload\$fileAppName"
+    $payloadPath = Join-Path $projectPath "payload\"$fileAppName
 
     New-Item -ItemType Directory -Force -Path $payloadPath | Out-Null
 

--- a/windows/install/makeInstallElectronite.ps1
+++ b/windows/install/makeInstallElectronite.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-    Creates a Windows installer package for the Liminal application.
+    Creates a Windows installer package for the application.
 
 .DESCRIPTION
-    This PowerShell script prepares and builds a Windows installer for the Liminal application using Inno Setup.
+    This PowerShell script prepares and builds a Windows installer for the application using Inno Setup.
     It creates the necessary directory structure, copies required files, and compiles the installer.
 
 .PARAMETER arch
@@ -14,11 +14,11 @@
     - APP_VERSION environment variable must be set (e.g., $env:APP_VERSION = "0.2.6")
 
 .OUTPUTS
-    Creates an installer at releases\windows\$arch\liminal_installer_*.exe
+    Creates an installer at releases\windows\$arch\<app-name>_installer_*.exe
 
 .NOTES
     - Cleans up existing installers before building
-    - Creates directory structure in .\windows\temp\project\payload\Liminal
+    - Creates directory structure in .\windows\temp\project\payload\<app-name>
     - Copies necessary files including Electron, README, bin, and lib directories
     - Compiles the installer using Inno Setup
 #>
@@ -35,14 +35,14 @@ try {
     # Check if APP_VERSION environment variable is set
     if (-not $env:APP_VERSION) {
         Write-Host "Error: APP_VERSION environment variable is not set."
-        Write-Host "Set it in PowerShell using: `$env:APP_VERSION = '0.2.6'"
+        Write-Host "Set it in app_config.env"
         exit 1
     }
     
     # Check if APP_NAME environment variable is set
     if (-not $env:APP_NAME) {
         Write-Host "Error: APP_NAME environment variable is not set."
-        Write-Host "Set it in PowerShell using: `$env:APP_NAME = 'Limimal"
+        Write-Host "Set it in app_config.env"
         exit 1
     }
     
@@ -57,7 +57,7 @@ try {
     Write-Host "Version is $env:APP_VERSION"
 
     # Clean up any existing installers
-    Get-ChildItem -Path "..\..\releases\windows\liminal_installer_*.exe" | Remove-Item -Force
+    Get-ChildItem -Path "..\..\releases\windows\"$fileAppName"_installer_*.exe" | Remove-Item -Force
 
     # Change to build directory
     Set-Location -Path "..\build" -ErrorAction Stop
@@ -68,7 +68,7 @@ try {
     # Clean up and create project directories
     Remove-Item -Path "..\temp\project" -Recurse -Force -ErrorAction SilentlyContinue
     $projectPath = "..\temp\project"
-    $payloadPath = Join-Path $projectPath "payload\Liminal"
+    $payloadPath = Join-Path $projectPath "payload\$fileAppName"
 
     New-Item -ItemType Directory -Force -Path $payloadPath | Out-Null
 


### PR DESCRIPTION
- Remove app-name hardcodes ("Liminal" and "liminal", mostly in comments)
- Organize artifacts alphabetically by operating system
- Include "setup" in all windows exe filenames
- Stop re-reruns: 
  - "No re-runs. They use the commit SHA and git ref of the original event that triggered the workflow run. However, that does not extend to client and resource repos which may expect a more recent panksomia-web. Start a new workflow run instead."
