### PR TITLE
@tidic84 electron leaving message

### DIFF
--- a/buildResources/electron/preload.js
+++ b/buildResources/electron/preload.js
@@ -1,0 +1,4 @@
+const { contextBridge, ipcRenderer } = require('electron')
+contextBridge.exposeInMainWorld('electronAPI', {
+  setCanClose: (canClose) => ipcRenderer.send('setCanClose', canClose)
+})


### PR DESCRIPTION
These are [tidic84](https://github.com/tidic84)'s changes reproduced from desktop-app-template origin.

This pull request add a display message (with electron) when the user try to leave the page while there are still unsaved changes.
- Added logic in `electronStartup.js` to prevent window closing or navigation when there are unsaved changes, prompting the user with a confirmation dialog. Introduced a `canClose` flag, IPC communication (`setCanClose`), and a preload script to expose this functionality to the renderer process. 
- The client logic is in core-client-workspace [OBSEditorMuncher.jsx:L215](https://github.com/pankosmia/core-client-workspace/blob/b1165cca84efa2033e622c2862bd8640ad563986/src/munchers/OBS/OBSEditorMuncher.jsx#L215)
- The documentation of how I developed it is in the Pankosmia Documentation: [pankosmia.dev](https://pankosmia.dev/windows-electron-dev-tips/)