### PR TITLE
Fix GHA build issues

### DIFF
--- a/.github/workflows/linux-build-steps.yml
+++ b/.github/workflows/linux-build-steps.yml
@@ -18,6 +18,10 @@ jobs:
     outputs:
       tgz-name: ${{ steps.get-tgz-name.outputs.tgz-name }}
     
+    # Set process.env.CI to false to prevent treating warnings as errors
+    env:
+      CI: false
+
     steps:
       # Turn off re-runs
       - name: No re-runs please

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -36,7 +36,11 @@ jobs:
       zip-name: ${{ steps.get-zip-name.outputs.zip-name }}
       pkg-name-arm: ${{ steps.get-installer-names.outputs.pkg-name-arm }}
       pkg-name-intel: ${{ steps.get-installer-names.outputs.pkg-name-intel }}
-    
+
+    # Set process.env.CI to false to prevent treating warnings as errors
+    env:
+      CI: false
+
     steps:
       # Turn off re-runs
       - name: No re-runs please

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -73,6 +73,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      # Specify node.js version
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.11.0'
+
       # Install the repository
       - name: Install this repo
         run: npm install

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -52,6 +52,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      # Specify node.js version
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.11.0'
+
       # Set APP_VERSION from app_config.env
       - name: Extract APP_VERSION from app_config.env
         id: get_app_version

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -25,7 +25,11 @@ jobs:
       zip-name: ${{ steps.get-zip-name.outputs.zip-name }}
       exe-name: ${{ steps.get-exe-name.outputs.exe-name }}
       electronite-exe-name: ${{ steps.get-electronite-exe-name.outputs.electronite-exe-name }}
-    
+
+    # Set process.env.CI to false to prevent treating warnings as errors
+    env:
+      CI: false
+
     steps:
       # Turn off re-runs
       - name: No re-runs please


### PR DESCRIPTION
- Specify Node.js v20.11.0 for Windows and MacOS
- Set CI environment variable to false to prevent warnings from being treated as errors.