### PR TITLE
Persistent electron menus for all OS' with Le-rg-o

### DIFF
--- a/buildResources/electron/electronDevStartup.js
+++ b/buildResources/electron/electronDevStartup.js
@@ -66,9 +66,21 @@ function InitializeMenu() {
     {
       label: 'Window',
       submenu: [
-        {role: 'reload'},
-        {role: 'forcereload'},
-        {role: 'toggledevtools'}
+        {
+          label: 'Reload',
+          accelerator: isMac ? 'Cmd+R' : 'Ctrl+R',
+          click: (menuItem, bw) => { if (bw) bw.webContents.reload(); }
+        },
+        {
+          label: 'Force Reload',
+          accelerator: isMac ? 'Shift+Cmd+R' : 'Ctrl+Shift+R',
+          click: (menuItem, bw) => { if (bw) bw.webContents.reloadIgnoringCache(); }
+        },
+        {
+          label: 'Toggle Developer Tools',
+          accelerator: isMac ? 'Alt+Cmd+I' : 'Ctrl+Shift+I',
+          click: (menuItem, bw) => { if (bw) bw.webContents.toggleDevTools(); }
+        }
         // {role: 'minimize'},
         // {role: 'zoom'},
         // {type: 'separator'},

--- a/buildResources/electron/electronStartup.js
+++ b/buildResources/electron/electronStartup.js
@@ -80,9 +80,21 @@ function InitializeMenu() {
     {
       label: 'Window',
       submenu: [
-        {role: 'reload'},
-        {role: 'forcereload'},
-        {role: 'toggledevtools'}
+        {
+          label: 'Reload',
+          accelerator: isMac ? 'Cmd+R' : 'Ctrl+R',
+          click: (menuItem, bw) => { if (bw) bw.webContents.reload(); }
+        },
+        {
+          label: 'Force Reload',
+          accelerator: isMac ? 'Shift+Cmd+R' : 'Ctrl+Shift+R',
+          click: (menuItem, bw) => { if (bw) bw.webContents.reloadIgnoringCache(); }
+        },
+        {
+          label: 'Toggle Developer Tools',
+          accelerator: isMac ? 'Alt+Cmd+I' : 'Ctrl+Shift+I',
+          click: (menuItem, bw) => { if (bw) bw.webContents.toggleDevTools(); }
+        }
         // {role: 'minimize'},
         // {role: 'zoom'},
         // {type: 'separator'},


### PR DESCRIPTION
@Le-rg-o , this PR is removes the menu items we discusses removing, and add a persistent menu that is always present (no use of Alt to unhide/hide).

## To fully test this PR, we need to:
1) Build the dev viewer for each platform and test. Windows, Linux Ubuntu, MacOS ARM, and MacOS Intel have all been tested, resulting in he screenshots below.
2) Install the [stand-alone artifacts built from this branch](https://github.com/pankosmia/desktop-app-template/actions/runs/19902705927) for each OS. Windows, Linux Ubuntu, MacOS ARM, and MacOS Intel have all been installed, with menus confirmed as matching the dev screenshots below.
3) And we need to confirm that the menu items and submenu items for each OS are as intended. I will update this note here with screenshots from each to simplify your review.

## Process:
- After this PR is merged, we'll then subsequently sync these updates to all forks, currently Pithekos, Liminal, TC4, and Renaissance.
- FYI, realizing that TC4 has an old pattern they are used to, we can make theirs work differently if needed (e.g., ALT to unhide/hide, or menu item differences). However,  it will be simpler to leave all the same until such requests are made, if ever.

## Screenshots:
| OS | App | Edit | View | Window |
|---|---|---|---|---|
| Windows | | <img width="288" height="264" alt="image" src="https://github.com/user-attachments/assets/98782f07-3c5e-4ed2-8824-6a5be51571ad" /> | <img width="289" height="195" alt="image" src="https://github.com/user-attachments/assets/04a812da-af43-458f-83d1-a163c62342ae" /> | <img width="321" height="178" alt="image" src="https://github.com/user-attachments/assets/bea2daac-1c87-400c-b2db-861c2a854a9c" /> |
| Linux | | <img width="624" height="292" alt="image" src="https://github.com/user-attachments/assets/625f8e7d-2b43-4b5f-9442-686ce6b63cb6" /> | <img width="611" height="177" alt="image" src="https://github.com/user-attachments/assets/f3b26706-ba17-439b-934a-c35e236ea0c2" /> | <img width="622" height="194" alt="image" src="https://github.com/user-attachments/assets/1d50ef5b-9430-4d6f-aaf6-03d4c4ea2aaa" /> |
| MacOS ARM | <img width="611" height="154" alt="Screenshot 2025-12-03 at 12 17 56 PM" src="https://github.com/user-attachments/assets/28962981-d8fe-4aac-9550-828d5f2937d5" /> | <img width="602" height="259" alt="Screenshot 2025-12-03 at 12 20 48 PM" src="https://github.com/user-attachments/assets/1ecf4698-a33d-41cc-9134-1ba486583929" /> | <img width="613" height="122" alt="Screenshot 2025-12-03 at 12 21 12 PM" src="https://github.com/user-attachments/assets/95bb2cc3-9ae4-4d80-a124-3ae0699eefe8" /> | <img width="610" height="112" alt="Screenshot 2025-12-03 at 12 21 26 PM" src="https://github.com/user-attachments/assets/34557082-30c7-4426-af7a-a83f78372b3e" /> |
| MacOS Intel | <img width="604" height="142" alt="Screen Shot 2025-12-03 at 2 58 40 PM" src="https://github.com/user-attachments/assets/5c2ac08c-abef-4a37-b116-7f9167db6e51" /> | <img width="617" height="285" alt="Screen Shot 2025-12-03 at 2 58 55 PM" src="https://github.com/user-attachments/assets/978f46ff-70cd-4ef0-ab50-26de58462f52" /> | <img width="609" height="215" alt="Screen Shot 2025-12-03 at 2 59 11 PM" src="https://github.com/user-attachments/assets/15bdf217-37f2-412d-86b7-e08c19a34546" /> | <img width="596" height="144" alt="Screen Shot 2025-12-03 at 2 59 27 PM" src="https://github.com/user-attachments/assets/a89e2a21-faa0-42ec-8a38-c4be5498e62e" /> |