### PR TITLE
Protestant books only config

### DIFF
--- a/globalBuildResources/client_config.json
+++ b/globalBuildResources/client_config.json
@@ -11,5 +11,23 @@
         }
       ]
     }
+  ],
+  "core-contenthandler_text_translation": [
+    {
+      "id": "config",
+      "i18n": "Config Menu",
+      "fields": [
+        {
+          "id": "protestantBooksOnlyCheckbox",
+          "i18n": "Protestant Books Only Checkbox",
+          "value": true
+        },
+        {
+          "id": "protestantBooksOnlyDefaultChecked",
+          "i18n": "Protestant Books Only Default Checked",
+          "value": true
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
There are 4 possible configurations resulting from this PR:

1. Default (no change to current display):
  - protestantBooksOnlyCheckbox set to true
  - protestantBooksOnlyDefaultChecked set to true

2. Protestant Books Only not checked by default:
  - protestantBooksOnlyCheckbox set to true
  - protestantBooksOnlyDefaultChecked set to false

3. Checkbox not displayed at all with only protestant books listed:
  - protestantBooksOnlyCheckbox set to false
  - protestantBooksOnlyDefaultChecked set to false

4. Checkbox not displayed at all with more than just protestant books listed:
  - protestantBooksOnlyCheckbox set to false
  - protestantBooksOnlyDefaultChecked set to true