### PR TITLE
GHA (or local) choice of all of qa, dev, or main 

### DIFF
--- a/.github/workflows/buildMaster.yml
+++ b/.github/workflows/buildMaster.yml
@@ -8,6 +8,16 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
+      branches:
+        description: 'Branches'
+        required: true
+        type: choice
+        options:
+          - all of main
+          - all of qa
+          - all of dev
+        default: all of main
+
       os:
         description: 'OS'
         required: true
@@ -29,13 +39,18 @@ on:
         default: release
 
 # set run name from input so the run appears with that name (no API call needed)
-run-name: Master Build - ${{ inputs.os }} - ${{ inputs.server_type }} server
+run-name: >-
+  Master Build
+  - ${{ inputs.branches }}
+  - ${{ inputs.os == 'all' && 'all OSes' || inputs.os }}
+  - ${{ inputs.server_type }} server
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - run: |
+          echo "Branches is ${{ inputs.branches }}"
           echo "OS is ${{ inputs.os }}"
           echo "Server type is ${{ inputs.server_type }}"
 
@@ -47,6 +62,7 @@ jobs:
       runner: macos-15-intel
       delay_seconds: 1
       server_type: ${{ inputs.server_type }}
+      branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
 
   build-macos-arm:
     name: Build on macOS ARM64 (Apple Silicon)
@@ -56,6 +72,7 @@ jobs:
       runner: macos-14
       delay_seconds: 600
       server_type: ${{ inputs.server_type }}
+      branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
 
   build-windows:
     name: Build on Windows x64
@@ -64,6 +81,7 @@ jobs:
     with:
       runner: windows-2025
       server_type: ${{ inputs.server_type }}
+      branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
 
   build-linux:
     name: Build on Linux x64
@@ -72,6 +90,7 @@ jobs:
     with:
       runner: ubuntu-22.04
       server_type: ${{ inputs.server_type }}
+      branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
 
   finalize:
     needs: [build-macos-intel, build-macos-arm, build-windows, build-linux]

--- a/.github/workflows/linux-build-steps.yml
+++ b/.github/workflows/linux-build-steps.yml
@@ -7,6 +7,9 @@ on:
         description: 'The GitHub runner to use (e.g., ubuntu-20.04, ubuntu-22.04)'
         required: true
         type: string
+      branches:
+        required: true
+        type: string
       server_type:
         required: true
         type: string
@@ -28,9 +31,14 @@ jobs:
     # Set process.env.CI to false to prevent treating warnings as errors
     env:
       CI: false
+      BRANCHES: ${{ inputs.branches }}
       SERVER_TYPE: ${{ inputs.server_type }}
 
     steps:
+      # Show branches
+      - name: Show BRANCHES
+        run: echo "BRANCHES = $BRANCHES"
+
       # Show server type
       - name: Show SERVER TYPE
         run: echo "SERVER_TYPE = $SERVER_TYPE"
@@ -84,9 +92,9 @@ jobs:
         working-directory: ./linux/scripts
         run: ./clone.bsh
 
-      - name: Build clients
+      - name: Build ${{ inputs.branches }} clients
         working-directory: ./linux/scripts
-        run: ./build_clients.bsh
+        run: ./build_clients.bsh "$BRANCHES"
 
       - name: Build DEBUG server and assemble build environment without asking if the server is off
         working-directory: ./linux/scripts

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -8,6 +8,9 @@ on:
         description: 'The GitHub runner to use (e.g., macos-13, macos-14)'
         required: true
         type: string
+      branches:
+        required: true
+        type: string
       server_type:
         required: true
         type: string
@@ -43,9 +46,14 @@ jobs:
     # Set process.env.CI to false to prevent treating warnings as errors
     env:
       CI: false
+      BRANCHES: ${{ inputs.branches }}
       SERVER_TYPE: ${{ inputs.server_type }}
 
     steps:
+      # Show branches
+      - name: Show BRANCHES
+        run: echo "BRANCHES = $BRANCHES"
+
       # Show server type
       - name: Show SERVER TYPE
         run: echo "SERVER_TYPE = $SERVER_TYPE"
@@ -121,9 +129,9 @@ jobs:
         working-directory: ./macos/scripts
         run: ./clone.zsh
 
-      - name: Build clients
+      - name: Build ${{ inputs.branches }} clients
         working-directory: ./macos/scripts
-        run: ./build_clients.zsh
+        run: ./build_clients.zsh "$BRANCHES"
 
       - name: Build DEBUG server and assemble build environment without asking if the server is off
         working-directory: ./macos/scripts

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -7,6 +7,9 @@ on:
         description: 'The GitHub runner to use (e.g., windows-2022, windows-2025)'
         required: true
         type: string
+      branches:
+        required: true
+        type: string
       server_type:
         required: true
         type: string
@@ -32,9 +35,14 @@ jobs:
     # Set process.env.CI to false to prevent treating warnings as errors
     env:
       CI: false
+      BRANCHES: ${{ inputs.branches }}
       SERVER_TYPE: ${{ inputs.server_type }}
 
     steps:
+      # Show branches
+      - name: Show BRANCHES
+        run: echo "BRANCHES = $BRANCHES"
+
       # Show server type
       - name: Show SERVER TYPE
         run: echo "SERVER_TYPE = $SERVER_TYPE"
@@ -110,9 +118,9 @@ jobs:
         run: .\clone.bat
 
       # Install and build clients
-      - name: Run build_clients.bat
+      - name: Build ${{ inputs.branches }} clients
         working-directory: .\windows\scripts
-        run: .\build_clients.bat
+        run: .\build_clients.bat "$BRANCHES"
 
       # Build DEBUG server and assemble build environment without asking if the server is off
       - name: Run DEBUG build_server.bat -s -d

--- a/linux/scripts/build_clients.bsh
+++ b/linux/scripts/build_clients.bsh
@@ -2,22 +2,33 @@
 
 # Run from: pankosmia/<repo-name>/linux/scripts
 # Usage:
-#   ./build_clients.bsh
-# Delete past logs without asking:
-#   ./build_clients.bsh -d
+#   ./build_clients.bsh [branch] [-d]
+# Examples:
+#   ./build_clients.bsh              # defaults to "main"
+#   ./build_clients.bsh dev          # tries dev → qa → main
+#   ./build_clients.bsh qa -d        # tries qa → main, deletes past logs
+#   ./build_clients.bsh -d dev       # same as above, flags and branch in any order
 
 source ../../app_config.env
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# --- parse args (only -d) ---
+# --- parse args (-d flag and optional branch) ---
 deleteLogs="-no"
+BRANCH=""
 while [ $# -gt 0 ]; do
   if [ "$1" = "-d" ]; then
     deleteLogs="-d"
+  elif [ -z "$BRANCH" ]; then
+    BRANCH="$1"
   fi
   shift
 done
+
+# Default branch to main if not provided
+if [ -z "$BRANCH" ]; then
+  BRANCH="main"
+fi
 
 # --- delete past logs (prompt unless -d) ---
 if ls "${SCRIPT_DIR}"/build_clients_*.log >/dev/null 2>&1; then
@@ -61,6 +72,44 @@ markfail() {
   FAILS+=("[$1] $2 :: $3")
 }
 
+# --- checkout with fallback logic ---
+checkout_branch() {
+  local cb_type="$1"
+  local cb_repo="$2"
+
+  log "> git checkout $BRANCH..."
+  if run git checkout "$BRANCH"; then
+    return
+  fi
+
+  # Branch didn't exist — apply fallback logic
+  if [ "${BRANCH,,}" = "dev" ]; then
+    log "> Branch \"dev\" not found, trying \"qa\"..."
+    if run git checkout qa; then
+      return
+    fi
+    log "> Branch \"qa\" not found, falling back to \"main\"..."
+    if ! run git checkout main; then
+      markfail "$cb_type" "$cb_repo" "git checkout main (fallback from dev)"
+    fi
+    return
+  fi
+
+  if [ "${BRANCH,,}" = "qa" ]; then
+    log "> Branch \"qa\" not found, falling back to \"main\"..."
+    if ! run git checkout main; then
+      markfail "$cb_type" "$cb_repo" "git checkout main (fallback from qa)"
+    fi
+    return
+  fi
+
+  # Any other branch — fall back to main
+  log "> Branch \"$BRANCH\" not found, falling back to \"main\"..."
+  if ! run git checkout main; then
+    markfail "$cb_type" "$cb_repo" "git checkout main (fallback from $BRANCH)"
+  fi
+}
+
 # --- original counting approach ---
 count=$(wc -l < "../../app_config.env")
 
@@ -81,8 +130,7 @@ for ((i=1;i<=count;i++)); do
       log
     else
       cd "$asset"
-      log "> git checkout main..."
-      if ! run git checkout main; then markfail "ASSET" "$asset" "git checkout main"; fi
+      checkout_branch "ASSET" "$asset"
 
       log "> git pull..."
       if ! run git pull; then markfail "ASSET" "$asset" "git pull"; fi
@@ -107,8 +155,7 @@ for ((i=1;i<=count;i++)); do
       log
     else
       cd "$client"
-      log "> git checkout main..."
-      if ! run git checkout main; then markfail "CLIENT" "$client" "git checkout main"; fi
+      checkout_branch "CLIENT" "$client"
 
       log "> git pull..."
       if ! run git pull; then markfail "CLIENT" "$client" "git pull"; fi

--- a/macos/scripts/build_clients.zsh
+++ b/macos/scripts/build_clients.zsh
@@ -2,22 +2,33 @@
 
 # Run from: pankosmia/<repo-name>/linux/scripts
 # Usage:
-#   ./build_clients.zsh
-# Delete past logs without asking:
-#   ./build_clients.zsh -d
+#   ./build_clients.zsh [branch] [-d]
+# Examples:
+#   ./build_clients.zsh              # defaults to "main"
+#   ./build_clients.zsh dev          # tries dev → qa → main
+#   ./build_clients.zsh qa -d        # tries qa → main, deletes past logs
+#   ./build_clients.zsh -d dev       # same as above, flags and branch in any order
 
 source ../../app_config.env
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# --- parse args (only -d) ---
+# --- parse args (-d flag and optional branch) ---
 deleteLogs="-no"
+BRANCH=""
 while [ $# -gt 0 ]; do
   if [ "$1" = "-d" ]; then
     deleteLogs="-d"
+  elif [ -z "$BRANCH" ]; then
+    BRANCH="$1"
   fi
   shift
 done
+
+# Default branch to main if not provided
+if [ -z "$BRANCH" ]; then
+  BRANCH="main"
+fi
 
 # --- delete past logs (prompt unless -d) ---
 if ls "${SCRIPT_DIR}"/build_clients_*.log >/dev/null 2>&1; then
@@ -61,6 +72,45 @@ markfail() {
   FAILS+=("[$1] $2 :: $3")
 }
 
+# --- checkout with fallback logic ---
+checkout_branch() {
+  local cb_type="$1"
+  local cb_repo="$2"
+  local branch_lower="${BRANCH:l}"   # zsh lowercase
+
+  log "> git checkout $BRANCH..."
+  if run git checkout "$BRANCH"; then
+    return
+  fi
+
+  # Branch didn't exist — apply fallback logic
+  if [ "$branch_lower" = "dev" ]; then
+    log "> Branch \"dev\" not found, trying \"qa\"..."
+    if run git checkout qa; then
+      return
+    fi
+    log "> Branch \"qa\" not found, falling back to \"main\"..."
+    if ! run git checkout main; then
+      markfail "$cb_type" "$cb_repo" "git checkout main (fallback from dev)"
+    fi
+    return
+  fi
+
+  if [ "$branch_lower" = "qa" ]; then
+    log "> Branch \"qa\" not found, falling back to \"main\"..."
+    if ! run git checkout main; then
+      markfail "$cb_type" "$cb_repo" "git checkout main (fallback from qa)"
+    fi
+    return
+  fi
+
+  # Any other branch — fall back to main
+  log "> Branch \"$BRANCH\" not found, falling back to \"main\"..."
+  if ! run git checkout main; then
+    markfail "$cb_type" "$cb_repo" "git checkout main (fallback from $BRANCH)"
+  fi
+}
+
 # --- original counting approach ---
 count=$(wc -l < "../../app_config.env")
 
@@ -81,8 +131,7 @@ for ((i=1;i<=count;i++)); do
       log
     else
       cd "$asset"
-      log "> git checkout main..."
-      if ! run git checkout main; then markfail "ASSET" "$asset" "git checkout main"; fi
+      checkout_branch "ASSET" "$asset"
 
       log "> git pull..."
       if ! run git pull; then markfail "ASSET" "$asset" "git pull"; fi
@@ -107,8 +156,7 @@ for ((i=1;i<=count;i++)); do
       log
     else
       cd "$client"
-      log "> git checkout main..."
-      if ! run git checkout main; then markfail "CLIENT" "$client" "git checkout main"; fi
+      checkout_branch "CLIENT" "$client"
 
       log "> git pull..."
       if ! run git pull; then markfail "CLIENT" "$client" "git pull"; fi

--- a/windows/scripts/build_clients.bat
+++ b/windows/scripts/build_clients.bat
@@ -1,19 +1,32 @@
 @echo off
-REM Run from pankosmia\[this-repo's-name]\windows\scripts directory in PowerShell or cmd by:  .\build_clients.bat
+REM Run from pankosmia\[this-repo's-name]\windows\scripts directory in PowerShell with `.\build_clients.bat`, or in cmd with `build_clients.bat`.
 
 REM The -d positional argument means to delete past logs without asking
+REM The first non-flag positional argument is the branch name (default: main)
 set "deleteLogs="
+set "BRANCH="
 
 :loop
 if "%~1"=="" goto :continue
-if /I "%~1"=="-d" set "deleteLogs=-d"
+if /I "%~1"=="-d" (
+  set "deleteLogs=-d"
+  shift
+  goto :loop
+)
+REM First non-flag argument is the branch
+if not defined BRANCH (
+  set "BRANCH=%~1"
+  shift
+  goto :loop
+)
 shift
 goto :loop
 
 :continue
 
-REM Assign default value if -d is not present
+REM Assign default values
 if not defined deleteLogs set "deleteLogs=-no"
+if not defined BRANCH set "BRANCH=main"
 
 if exist "build_clients_*.log" (
   echo.
@@ -84,9 +97,7 @@ for /l %%a in (1,1,%count%) do (
       call :log
     ) else (
       cd !ASSET%%a!
-      call :log ^> git checkout main...
-      call :run git checkout main
-      if errorlevel 1 call :markfail "ASSET" "!ASSET%%a!" "git checkout main"
+      call :checkout_branch "ASSET" "!ASSET%%a!"
 
       call :log ^> git pull...
       call :run git pull
@@ -112,9 +123,7 @@ for /l %%a in (1,1,%count%) do (
       call :log
     ) else (
       cd !CLIENT%%a!
-      call :log ^> git checkout main...
-      call :run git checkout main
-      if errorlevel 1 call :markfail "CLIENT" "!CLIENT%%a!" "git checkout main"
+      call :checkout_branch "CLIENT" "!CLIENT%%a!"
 
       call :log ^> git pull...
       call :run git pull
@@ -159,6 +168,44 @@ if %FAILCOUNT% GTR 0 set "EXITCODE=1"
 
 endlocal
 exit /b %EXITCODE%
+
+
+:checkout_branch
+REM %~1 = type (ASSET or CLIENT), %~2 = repo name
+REM Uses %BRANCH% to determine which branch to check out, with fallback logic.
+set "CB_TYPE=%~1"
+set "CB_REPO=%~2"
+
+call :log ^> git checkout %BRANCH%...
+call :run git checkout %BRANCH%
+if not errorlevel 1 goto :checkout_done
+
+REM Branch didn't exist — apply fallback logic
+if /I "%BRANCH%"=="dev" (
+  call :log ^> Branch "dev" not found, trying "qa"...
+  call :run git checkout qa
+  if not errorlevel 1 goto :checkout_done
+
+  call :log ^> Branch "qa" not found, falling back to "main"...
+  call :run git checkout main
+  if errorlevel 1 call :markfail "%CB_TYPE%" "%CB_REPO%" "git checkout main (fallback from dev)"
+  goto :checkout_done
+)
+
+if /I "%BRANCH%"=="qa" (
+  call :log ^> Branch "qa" not found, falling back to "main"...
+  call :run git checkout main
+  if errorlevel 1 call :markfail "%CB_TYPE%" "%CB_REPO%" "git checkout main (fallback from qa)"
+  goto :checkout_done
+)
+
+REM Any other branch — fall back to main
+call :log ^> Branch "%BRANCH%" not found, falling back to "main"...
+call :run git checkout main
+if errorlevel 1 call :markfail "%CB_TYPE%" "%CB_REPO%" "git checkout main (fallback from %BRANCH%)"
+
+:checkout_done
+exit /b 0
 
 
 :log


### PR DESCRIPTION
This handles Asset and Client branch selection.

# To apply locally:
- `./build_clients.bsh [BRANCH_NAME]` where "[BRANCH_NAME]" is "dev", "qa" or "main".  (or .zsh or .bat)
  - If "dev" but "dev" does not yet exist for a reop, then it falls back to "qa" for that repo.
  - If "qa" but "qa" does not yet exist for a repo, then it falls back to "main" for that repo.
- **_BONUS:_** actually, on local you can insert any branch name. 
  - If that branch name does not exist for a repo, then it fall back to "main" for that repo.
  - **_USE:_**  If developing a new branch but other repos are falling behind and main will do for them, and we just want it to run and catch things up while we work...
 
# Github Actions:
## Select the set of branches to use from the dropdown:
<img width="338" height="296" alt="image" src="https://github.com/user-attachments/assets/68db7ccc-5271-4490-b038-07524a41a6d4" />

## To see this dropdown prior to merging:
On the Master Build "Run workflow" options, choose this branch (/run/specify_ branch)
<img width="317" height="269" alt="image" src="https://github.com/user-attachments/assets/bc2f0c23-28e4-431a-9c6f-115ca80a6cbd" />
The "Branches" dropdown will be added once this "Run workflow" selection is set.

## To see the branch choice in action:
1. On the Actions page, drill down on a "Master Build" line that includes "- all of qa -" or "- all of dev -"  (or "- all of main-" but that won't show fallback)
2. Drill down again on a "Build on [os]" line with a green check mark next to it (or a red x if not successful)
3. Expand the "Build dev clients >" section and note that for each repo that it checks out the specified branch and then falls back where it doesn't exist.

For example, this what was see in the log for "Asset 1: resource-core" for "- all of dev -", which is what we want.  There is no dev, so it falls back to qa, and there is no qa so it falls back to main.:
```
> git checkout dev...
error: pathspec 'dev' did not match any file(s) known to git
> Branch "dev" not found, trying "qa"...
error: pathspec 'qa' did not match any file(s) known to git
> Branch "qa" not found, falling back to "main"...
Already on 'main'
Your branch is up to date with 'origin/main'.
> git pull...
Already up to date.
```

And this is what we see the log for "Client 1: core-client-dashboard" for "- all of dev -":
```
> git checkout dev...
Switched to a new branch 'dev'
branch 'dev' set up to track 'origin/dev'.
> git pull...
Already up to date.
> npm ci...
```