### PR TITLE
Add local server dev and qa versions

### DIFF
--- a/.github/workflows/linux-build-steps.yml
+++ b/.github/workflows/linux-build-steps.yml
@@ -96,15 +96,15 @@ jobs:
         working-directory: ./linux/scripts
         run: ./build_clients.bsh "$BRANCHES"
 
-      - name: Build DEBUG server and assemble build environment without asking if the server is off
+      - name: Build ${{ inputs.branches }} DEBUG server and assemble build environment without asking if the server is off
         working-directory: ./linux/scripts
         if: env.SERVER_TYPE == 'debug'
-        run: ./build_server.bsh -s -d
+        run: ./build_server.bsh -s -d "$BRANCHES"
 
-      - name: Build RELEASE server and assemble build environment without asking if the server is off
+      - name: Build ${{ inputs.branches }} RELEASE server and assemble build environment without asking if the server is off
         working-directory: ./linux/scripts
         if: env.SERVER_TYPE == 'release'
-        run: ./build_server.bsh -s
+        run: ./build_server.bsh -s "$BRANCHES"
 
       - name: Bundle tgz without asking if the server is off and indicate GHA
         working-directory: ./linux/scripts

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -133,15 +133,15 @@ jobs:
         working-directory: ./macos/scripts
         run: ./build_clients.zsh "$BRANCHES"
 
-      - name: Build DEBUG server and assemble build environment without asking if the server is off
+      - name: Build ${{ inputs.branches }} DEBUG server and assemble build environment without asking if the server is off
         working-directory: ./macos/scripts
         if: env.SERVER_TYPE == 'debug'
-        run: ./build_server.zsh -s -d
+        run: ./build_server.zsh -s -d "$BRANCHES"
 
-      - name: Build RELEASE server and assemble build environment without asking if the server is off
+      - name: Build ${{ inputs.branches }} RELEASE server and assemble build environment without asking if the server is off
         working-directory: ./macos/scripts
         if: env.SERVER_TYPE == 'release'
-        run: ./build_server.zsh -s
+        run: ./build_server.zsh -s "$BRANCHES"
 
       - name: Bundle zip without asking if the server is off and indicate GHA
         working-directory: ./macos/scripts

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -123,16 +123,16 @@ jobs:
         run: .\build_clients.bat "$BRANCHES"
 
       # Build DEBUG server and assemble build environment without asking if the server is off
-      - name: Run DEBUG build_server.bat -s -d
+      - name: Run ${{ inputs.branches }} DEBUG server and assemble build environment without asking if the server is off
         working-directory: .\windows\scripts
         if: env.SERVER_TYPE == 'debug'
-        run: .\build_server.bat -s -d
+        run: .\build_server.bat -s -d "$BRANCHES"
 
       # Build RELEASE server and assemble build environment without asking if the server is off
-      - name: Run RELEASE build_server.bat -s
+      - name: Run ${{ inputs.branches }} RELEASE server and assemble build environment without asking if the server is off
         working-directory: .\windows\scripts
         if: env.SERVER_TYPE == 'release'
-        run: .\build_server.bat -s
+        run: .\build_server.bat -s "$BRANCHES"
 
       # Bundle zip without asking if the server is off and indicate GHA
       - name: Run bundle_zip.ps1 -ServerOff "Y" -IsGHA "Y"

--- a/linux/scripts/build_server.bsh
+++ b/linux/scripts/build_server.bsh
@@ -5,23 +5,66 @@ set -u
 
 echo
 
-# Do not ask if the server is off if the -s positional argument is provided in either #1 or #2
-# Debug server if the -d positional argument is provided in either #1 or #2
+# Do not ask if the server is off if the -s positional argument is provided
+# Debug server if the -d positional argument is provided
+# Specify environment as first non-flag positional argument: dev, qa, or main (default: main)
+envArg=""
 while [[ "$#" -gt 0 ]]
   do case $1 in
       -s) askIfOff="$1" # -s = "no"
       ;;
       -d) debugServer="$1" # -d = "yes"
+      ;;
+      *) if [ -z "$envArg" ] && [[ "$1" != -* ]]; then
+           envArg="$1"
+         fi
+      ;;
   esac
   shift
 done
+
+# Normalize: anything other than dev or qa is treated as main
+if [ -z "$envArg" ]; then
+  envArg="main"
+fi
+if [ "$envArg" != "dev" ] && [ "$envArg" != "qa" ]; then
+  envArg="main"
+fi
+
+# For dev and qa, back up Cargo.toml and rewrite the pankosmia_web version
+# For main, Cargo.toml already has the correct version — no replacement needed
+cargoFile="../../local_server/Cargo.toml"
+cargoBackup="../../local_server/Cargo.toml.bak"
+didRewrite=0
+
+restore_cargo() {
+  if [ "$didRewrite" -eq 1 ] && [ -f "$cargoBackup" ]; then
+    cp "$cargoBackup" "$cargoFile"
+    rm "$cargoBackup"
+  fi
+}
+trap restore_cargo EXIT
+
+if [ "$envArg" != "main" ]; then
+  targetVersion=$(grep "^${envArg}=" "../../local_server.env" | cut -d'=' -f2)
+  if [ -z "$targetVersion" ]; then
+    echo "  Could not find environment \"$envArg\" in local_server.env"
+    exit 1
+  fi
+  echo "  Using pankosmia_web version $targetVersion for environment \"$envArg\""
+  cp "$cargoFile" "$cargoBackup"
+  sed -i "s|pankosmia_web = \"=[^\"]*\"|pankosmia_web = \"=$targetVersion\"|" "$cargoFile"
+  didRewrite=1
+else
+  echo "  Using pankosmia_web version from Cargo.toml (main)"
+fi
 
 # Assign default value if -s is not present
 if [ -z ${askIfOff+x} ]; then # serverOff is unset
   askIfOff=-yes
 fi
 
-# Assign default value if -s is not present
+# Assign default value if -d is not present
 if [ -z ${debugServer+x} ]; then # debugServer is unset
   debugServer=-no
   buildCommand="cargo build --release"
@@ -77,6 +120,8 @@ echo "Building local $serverType server at /$replace ..."
 cd ../../local_server
 $buildCommand
 cd ../linux/scripts
+
+# Cargo.toml is restored by the EXIT trap
 
 if [ -d ../build ]; then
   echo "Removing last build environment..."

--- a/local_server.env
+++ b/local_server.env
@@ -1,0 +1,3 @@
+dev=0.14.6
+qa=0.14.7
+# main will use the version number in `local_server\Cargo.toml`

--- a/macos/scripts/build_server.zsh
+++ b/macos/scripts/build_server.zsh
@@ -5,23 +5,66 @@ set -u
 
 echo
 
-# Do not ask if the server is off if the -s positional argument is provided in either #1 or #2
-# Debug server if the -d positional argument is provided in either #1 or #2
+# Do not ask if the server is off if the -s positional argument is provided
+# Debug server if the -d positional argument is provided
+# Specify environment as first non-flag positional argument: dev, qa, or main (default: main)
+envArg=""
 while [[ "$#" -gt 0 ]]
   do case $1 in
       -s) askIfOff="$1" # -s means "no"
       ;;
       -d) debugServer="$1" # -d = "yes"
+      ;;
+      *) if [ -z "$envArg" ] && [[ "$1" != -* ]]; then
+           envArg="$1"
+         fi
+      ;;
   esac
   shift
 done
+
+# Normalize: anything other than dev or qa is treated as main
+if [ -z "$envArg" ]; then
+  envArg="main"
+fi
+if [ "$envArg" != "dev" ] && [ "$envArg" != "qa" ]; then
+  envArg="main"
+fi
+
+# For dev and qa, back up Cargo.toml and rewrite the pankosmia_web version
+# For main, Cargo.toml already has the correct version — no replacement needed
+cargoFile="../../local_server/Cargo.toml"
+cargoBackup="../../local_server/Cargo.toml.bak"
+didRewrite=0
+
+restore_cargo() {
+  if [ "$didRewrite" -eq 1 ] && [ -f "$cargoBackup" ]; then
+    cp "$cargoBackup" "$cargoFile"
+    rm "$cargoBackup"
+  fi
+}
+trap restore_cargo EXIT
+
+if [ "$envArg" != "main" ]; then
+  targetVersion=$(grep "^${envArg}=" "../../local_server.env" | cut -d'=' -f2)
+  if [ -z "$targetVersion" ]; then
+    echo "  Could not find environment \"$envArg\" in local_server.env"
+    exit 1
+  fi
+  echo "  Using pankosmia_web version $targetVersion for environment \"$envArg\""
+  cp "$cargoFile" "$cargoBackup"
+  sed -i '' "s|pankosmia_web = \"=[^\"]*\"|pankosmia_web = \"=$targetVersion\"|" "$cargoFile"
+  didRewrite=1
+else
+  echo "  Using pankosmia_web version from Cargo.toml (main)"
+fi
 
 # Assign default value if -s is not present
 if [ -z ${askIfOff+x} ]; then # serverOff is unset
   askIfOff=-yes
 fi
 
-# Assign default value if -s is not present
+# Assign default value if -d is not present
 if [ -z ${debugServer+x} ]; then # debugServer is unset
   debugServer=-no
   buildCommand=(cargo build --release)
@@ -78,6 +121,8 @@ echo "Building local $serverType server at /$replace ..."
 cd ../../local_server
 OPENSSL_STATIC=yes "${buildCommand[@]}"
 cd ../macos/scripts
+
+# Cargo.toml is restored by the EXIT trap
 
 if [ -d ../build ]; then
   echo "Removing last build environment..."

--- a/windows/scripts/build_server.bat
+++ b/windows/scripts/build_server.bat
@@ -167,12 +167,21 @@ echo "Building local %serverType% server at /%replace% ..."
 cd ..\..\local_server
 echo "%buildCommand%"
 %buildCommand%
+set "buildResult=%errorlevel%"
 cd ..\windows\scripts
 
 REM Restore Cargo.toml if it was rewritten
 if "%didRewrite%"=="1" (
   copy "..\..\local_server\Cargo.toml.bak" "..\..\local_server\Cargo.toml" >nul
   del "..\..\local_server\Cargo.toml.bak"
+)
+
+REM Exit if the build failed
+if not "%buildResult%"=="0" (
+  echo.
+  echo      Build failed with exit code %buildResult%.
+  echo.
+  exit /b %buildResult%
 )
 
 REM Clean the build environment

--- a/windows/scripts/build_server.bat
+++ b/windows/scripts/build_server.bat
@@ -1,20 +1,85 @@
 @echo off
 REM Run from pankosmia\[this-repo's-name]\windows\scripts directory in powershell or command by:  .\build_server.bat
 
-REM Do not ask if the server is off if the -s positional argument is provided in either #1 or #2
-REM Debug server if the -d positional argument is provided in either #1 or #2
+REM Do not ask if the server is off if the -s positional argument is provided
+REM Debug server if the -d positional argument is provided
+REM Specify environment as first non-flag positional argument: dev, qa, or main (default: main)
+set "envArg="
 :loop
 IF "%~1"=="" (
   goto :continue
-) ELSE IF "%~1"=="-s" (
+)
+IF "%~1"=="-s" (
   set "askIfOff=%~1"
-) ELSE IF "%~1"=="-d" (
+  shift
+  goto :loop
+)
+IF "%~1"=="-d" (
   set "debugServer=%~1"
+  shift
+  goto :loop
+)
+IF not defined envArg (
+  IF "%~1"=="dev" set "envArg=dev"
+  IF "%~1"=="qa" set "envArg=qa"
+  IF "%~1"=="main" set "envArg=main"
 )
 shift
 goto :loop
 
 :continue
+
+REM Normalize: anything other than dev or qa is treated as main
+if not defined envArg (
+  set "envArg=main"
+)
+if /I not "%envArg%"=="dev" if /I not "%envArg%"=="qa" (
+  set "envArg=main"
+)
+
+REM For dev and qa, back up Cargo.toml and rewrite the pankosmia_web version
+REM For main, Cargo.toml already has the correct version — no replacement needed
+set "cargoFile=..\..\local_server\Cargo.toml"
+set "cargoBackup=..\..\local_server\Cargo.toml.bak"
+set "didRewrite=0"
+
+if /I not "%envArg%"=="main" (
+  setlocal enabledelayedexpansion
+  set "targetVersion="
+  for /f "tokens=1,* delims==" %%a in ('type "..\..\local_server.env"') do (
+    if /I "%%a"=="%envArg%" (
+      set "targetVersion=%%b"
+    )
+  )
+  if not defined targetVersion (
+    echo.
+    echo      Could not find environment "%envArg%" in local_server.env
+    echo.
+    exit /b 1
+  )
+  echo.
+  echo   Using pankosmia_web version !targetVersion! for environment "%envArg%"
+
+  copy "!cargoFile!" "!cargoBackup!" >nul
+
+  set "cargoTmp=..\..\local_server\Cargo.toml.tmp"
+  (for /f "usebackq tokens=*" %%a in ("!cargoBackup!") do (
+    set "line=%%a"
+    echo !line! | findstr /C:"pankosmia_web" >nul
+    if !errorlevel! equ 0 (
+      echo pankosmia_web = "=!targetVersion!"
+    ) else (
+      echo(!line!
+    )
+  )) > "!cargoTmp!"
+  move /y "!cargoTmp!" "!cargoFile!" >nul
+
+  endlocal
+  set "didRewrite=1"
+) else (
+  echo.
+  echo   Using pankosmia_web version from Cargo.toml ^(main^)
+)
 
 REM Assign default value if -s is not present
 if not defined %askIfOff (
@@ -54,6 +119,11 @@ echo      Exiting...
 echo.
 echo      If the server is on, turn it off by exiting the terminal window or app where it is running, then re-run this script.
 echo.
+REM Restore Cargo.toml if it was rewritten
+if "%didRewrite%"=="1" (
+  copy "..\..\local_server\Cargo.toml.bak" "..\..\local_server\Cargo.toml" >nul
+  del "..\..\local_server\Cargo.toml.bak"
+)
 exit
 
 :server_off
@@ -98,6 +168,12 @@ cd ..\..\local_server
 echo "%buildCommand%"
 %buildCommand%
 cd ..\windows\scripts
+
+REM Restore Cargo.toml if it was rewritten
+if "%didRewrite%"=="1" (
+  copy "..\..\local_server\Cargo.toml.bak" "..\..\local_server\Cargo.toml" >nul
+  del "..\..\local_server\Cargo.toml.bak"
+)
 
 REM Clean the build environment
 if exist ..\build (


### PR DESCRIPTION
## Adds:
- `local_server.env` for "dev" and "qa" server numbers. Cargo.toml keeps the "main" version number, just as we have been doing.
  - These are set to different numbers for testing; Reset all to `0.14.8` before merging.
- Run `./build_server.[ext] dev` or `./build_server.[ext] qa` to build the server with the respective version.
  - Any position is supported if run with other arguments.
  - `./build_server.[ext]` or `./build_server.[ext] main` or `./build_server.[ext] not_dev_or_qa` will build the server with the main version.
 - You can also test this on Github Actions prior to merging by telling Master Build to use the worfklow from `run/server_dev_qa`
<img width="339" height="444" alt="image" src="https://github.com/user-attachments/assets/4772ed91-8552-407f-9877-a5b7a8b6f74c" />

### How this works
- When dev or qa are specified, a backup is made of Cargo.toml before the version number is replaced.  Then after the server is either successfully built or the build fails, then the original Cargo.toml is restored.