### PR TITLE
Add product-specific resources to build.js scripts

### DIFF
--- a/globalBuildResources/product_resources/README.md
+++ b/globalBuildResources/product_resources/README.md
@@ -1,0 +1,3 @@
+The `/globalBuildResources/product_resources` directory houses app-specific data. An example of use is the Dashboard walk-through.
+
+For use in dev, on `run` the contents of this directory is copied to `/[os]/build/lib/app_resources/product/product_resources`.

--- a/linux/scripts/build.js
+++ b/linux/scripts/build.js
@@ -145,3 +145,9 @@ if (spec.client_config) {
         path.join(BUILD_DIR, "lib", "app_resources", "product", "client_config.json")
     );
 }
+// Product Resources
+fse.copySync(
+    path.resolve("../../globalBuildResources/product_resources"),
+    path.join(BUILD_DIR, "lib", "app_resources", "product", "product_resources"),
+    { recursive: true }
+);

--- a/macos/scripts/build.js
+++ b/macos/scripts/build.js
@@ -166,3 +166,9 @@ if (spec.client_config) {
         path.join(BUILD_DIR, "lib", "app_resources", "product", "client_config.json")
     );
 }
+// Product Resources
+fse.copySync(
+    path.resolve("../../globalBuildResources/product_resources"),
+    path.join(BUILD_DIR, "lib", "app_resources", "product", "product_resources"),
+    { recursive: true }
+);

--- a/windows/scripts/build.js
+++ b/windows/scripts/build.js
@@ -160,6 +160,13 @@ if (spec.client_config) {
     );
 }
 
+// Product Resources
+fse.copySync(
+    path.resolve("../../globalBuildResources/product_resources"),
+    path.join(BUILD_DIR, "lib", "app_resources", "product", "product_resources"),
+    { recursive: true }
+);
+
 const fixWindowsUtf8 = (srcFilePath, destFilePath) => {
     // Read the file with UTF-8 encoding
     fs.readFile(srcFilePath, 'utf8', (err, data) => {


### PR DESCRIPTION
# This is for #61

The new directory is `globalBuildResources/product_resources`, currently containing a single README file.
This directory and its contents are copied recursively with `node build.js` to `lib/app_resources/product/`

## Tested on:
- Linux run script
- Windows run script
- MacOS run script
- Windows standalone install
- Linux standalone install
- MacOS ARM standalone install (and this part of the script is the same for Intel)

Artifacts from this [workflow on this PR branch](https://github.com/pankosmia/desktop-app-template/actions/runs/24481172544) was used for testing stand-alone installs.