### PR TITLE
Friendlier Sync!

### DIFF
--- a/linux/scripts/sync.bsh
+++ b/linux/scripts/sync.bsh
@@ -4,8 +4,8 @@ set -e
 set -u
 
 doSync() {
-  git fetch upstream
-  git merge --no-log --no-ff --no-commit upstream/main || true
+  git fetch upstream main
+  git merge --no-log --no-ff --no-commit upstream/main > /dev/null || true
 
   # --- Protected files: these should not be overwritten by the upstream merge ---
   PROTECTED_FILES=(

--- a/linux/scripts/sync.bsh
+++ b/linux/scripts/sync.bsh
@@ -5,129 +5,83 @@ set -u
 
 doSync() {
   git fetch upstream
-  git merge --no-log --no-ff --no-commit upstream/main
-  echo package-lock.json:
-  git reset package-lock.json
-  git checkout package-lock.json
-  echo globalBuildResources/favicon.ico:
-  git reset globalBuildResources/favicon.ico
-  git checkout globalBuildResources/favicon.ico
-  echo globalBuildResources/icon.icns:
-  git reset globalBuildResources/icon.icns
-  git checkout globalBuildResources/icon.icns
-  echo globalBuildResources/icon.ico:
-  git reset globalBuildResources/icon.ico
-  git checkout globalBuildResources/icon.ico
-  echo globalBuildResources/linux_icon.png:
-  git reset globalBuildResources/linux_icon.png
-  git checkout globalBuildResources/linux_icon.png
-  echo globalBuildResources/favicon.png:
-  git reset globalBuildResources/favicon.png
-  git checkout globalBuildResources/favicon.png
-  echo globalBuildResources/favicon@1.25x.png:
-  git reset globalBuildResources/favicon@1.25x.png
-  git checkout globalBuildResources/favicon@1.25x.png
-  echo globalBuildResources/favicon@1.5x.png:
-  git reset globalBuildResources/favicon@1.5x.png
-  git checkout globalBuildResources/favicon@1.5x.png
-  echo globalBuildResources/favicon@1.75x.png:
-  git reset globalBuildResources/favicon@1.75x.png
-  git checkout globalBuildResources/favicon@1.75x.png
-  echo globalBuildResources/favicon@2x.png:
-  git reset globalBuildResources/favicon@2x.png
-  git checkout globalBuildResources/favicon@2x.png
-  echo globalBuildResources/theme.json:
-  git reset globalBuildResources/theme.json
-  git checkout globalBuildResources/theme.json
-  echo branding/building_blocks/for_favicon_ico/favicon_16x16.png:
-  git reset branding/building_blocks/for_favicon_ico/favicon_16x16.png
-  git checkout branding/building_blocks/for_favicon_ico/favicon_16x16.png
-  echo branding/building_blocks/for_favicon_ico/favicon_32x32.png:
-  git reset branding/building_blocks/for_favicon_ico/favicon_32x32.png
-  git checkout branding/building_blocks/for_favicon_ico/favicon_32x32.png
-  echo branding/building_blocks/for_icon_icns/icon_128x128.png:
-  git reset branding/building_blocks/for_icon_icns/icon_128x128.png
-  git checkout branding/building_blocks/for_icon_icns/icon_128x128.png
-  echo branding/building_blocks/for_icon_icns/icon_128x128@2x.png:
-  git reset branding/building_blocks/for_icon_icns/icon_128x128@2x.png
-  git checkout branding/building_blocks/for_icon_icns/icon_128x128@2x.png
-  echo branding/building_blocks/for_icon_icns/icon_16x16.png:
-  git reset branding/building_blocks/for_icon_icns/icon_16x16.png
-  git checkout branding/building_blocks/for_icon_icns/icon_16x16.png
-  echo branding/building_blocks/for_icon_icns/icon_16x16@2x.png:
-  git reset branding/building_blocks/for_icon_icns/icon_16x16@2x.png
-  git checkout branding/building_blocks/for_icon_icns/icon_16x16@2x.png
-  echo branding/building_blocks/for_icon_icns/icon_256x256.png:
-  git reset branding/building_blocks/for_icon_icns/icon_256x256.png
-  git checkout branding/building_blocks/for_icon_icns/icon_256x256.png
-  echo branding/building_blocks/for_icon_icns/icon_256x256@2x.png:
-  git reset branding/building_blocks/for_icon_icns/icon_256x256@2x.png
-  git checkout branding/building_blocks/for_icon_icns/icon_256x256@2x.png
-  echo branding/building_blocks/for_icon_icns/icon_32x32.png:
-  git reset branding/building_blocks/for_icon_icns/icon_32x32.png
-  git checkout branding/building_blocks/for_icon_icns/icon_32x32.png
-  echo branding/building_blocks/for_icon_icns/icon_32x32@2x.png:
-  git reset branding/building_blocks/for_icon_icns/icon_32x32@2x.png
-  git checkout branding/building_blocks/for_icon_icns/icon_32x32@2x.png
-  echo branding/building_blocks/for_icon_icns/icon_512x512.png:
-  git reset branding/building_blocks/for_icon_icns/icon_512x512.png
-  git checkout branding/building_blocks/for_icon_icns/icon_512x512.png
-  echo branding/building_blocks/for_icon_icns/icon_512x512@2x.png:
-  git reset branding/building_blocks/for_icon_icns/icon_512x512@2x.png
-  git checkout branding/building_blocks/for_icon_icns/icon_512x512@2x.png
-  echo branding/building_blocks/for_icon_ico/win_icon_16x16.png:
-  git reset branding/building_blocks/for_icon_ico/win_icon_16x16.png
-  git checkout branding/building_blocks/for_icon_ico/win_icon_16x16.png
-  echo branding/building_blocks/for_icon_ico/win_icon_256x256.png:
-  git reset branding/building_blocks/for_icon_ico/win_icon_256x256.png
-  git checkout branding/building_blocks/for_icon_ico/win_icon_256x256.png
-  echo branding/building_blocks/for_icon_ico/win_icon_32x32.png:
-  git reset branding/building_blocks/for_icon_ico/win_icon_32x32.png
-  git checkout branding/building_blocks/for_icon_ico/win_icon_32x32.png
-  echo branding/building_blocks/for_icon_ico/win_icon_48x48.png:
-  git reset branding/building_blocks/for_icon_ico/win_icon_48x48.png
-  git checkout branding/building_blocks/for_icon_ico/win_icon_48x48.png
-  echo branding/source/favicon.png:
-  git reset branding/source/favicon.png
-  git checkout branding/source/favicon.png
-  echo branding/source/mac_icon.png:
-  git reset branding/source/mac_icon.png
-  git checkout branding/source/mac_icon.png
-  echo branding/source/win_icon.png:
-  git reset branding/source/win_icon.png
-  git checkout branding/source/win_icon.png
-  echo branding/source/favicon.svg:
-  git reset branding/source/favicon.svg
-  git checkout branding/source/favicon.svg
-  echo branding/source/mac_icon.svg:
-  git reset branding/source/mac_icon.svg
-  git checkout branding/source/mac_icon.svg
-  echo branding/source/win_icon.svg:
-  git reset branding/source/win_icon.svg
-  git checkout branding/source/win_icon.svg
-  echo branding/source/artwork/favicon_transparent_square_blue-turqoise.psd:
-  git reset branding/source/artwork/favicon_transparent_square_blue-turqoise.psd
-  git checkout branding/source/artwork/favicon_transparent_square_blue-turqoise.psd
-  echo branding/source/artwork/logo_512.png:
-  git reset branding/source/artwork/logo_512.png
-  git checkout branding/source/artwork/logo_512.png
-  echo branding/source/artwork/logo_favicon_inkscape.svg:
-  git reset branding/source/artwork/logo_favicon_inkscape.svg
-  git checkout branding/source/artwork/logo_favicon_inkscape.svg
-  echo branding/source/artwork/logo_inkscape.svg:
-  git reset branding/source/artwork/logo_inkscape.svg
-  git checkout branding/source/artwork/logo_inkscape.svg
-  echo branding/source/artwork/logo_macos.psd:
-  git reset branding/source/artwork/logo_macos.psd
-  git checkout branding/source/artwork/logo_macos.psd
-  echo branding/source/artwork/logo_windows.psd:
-  git reset branding/source/artwork/logo_windows.psd
-  git checkout branding/source/artwork/logo_windows.psd
+  git merge --no-log --no-ff --no-commit upstream/main || true
+
+  # --- Protected files: these should not be overwritten by the upstream merge ---
+  PROTECTED_FILES=(
+    "package-lock.json"
+    "globalBuildResources/favicon.ico"
+    "globalBuildResources/icon.icns"
+    "globalBuildResources/icon.ico"
+    "globalBuildResources/linux_icon.png"
+    "globalBuildResources/favicon.png"
+    "globalBuildResources/favicon@1.25x.png"
+    "globalBuildResources/favicon@1.5x.png"
+    "globalBuildResources/favicon@1.75x.png"
+    "globalBuildResources/favicon@2x.png"
+    "globalBuildResources/theme.json"
+    "branding/building_blocks/for_favicon_ico/favicon_16x16.png"
+    "branding/building_blocks/for_favicon_ico/favicon_32x32.png"
+    "branding/building_blocks/for_icon_icns/icon_128x128.png"
+    "branding/building_blocks/for_icon_icns/icon_128x128@2x.png"
+    "branding/building_blocks/for_icon_icns/icon_16x16.png"
+    "branding/building_blocks/for_icon_icns/icon_16x16@2x.png"
+    "branding/building_blocks/for_icon_icns/icon_256x256.png"
+    "branding/building_blocks/for_icon_icns/icon_256x256@2x.png"
+    "branding/building_blocks/for_icon_icns/icon_32x32.png"
+    "branding/building_blocks/for_icon_icns/icon_32x32@2x.png"
+    "branding/building_blocks/for_icon_icns/icon_512x512.png"
+    "branding/building_blocks/for_icon_icns/icon_512x512@2x.png"
+    "branding/building_blocks/for_icon_ico/win_icon_16x16.png"
+    "branding/building_blocks/for_icon_ico/win_icon_256x256.png"
+    "branding/building_blocks/for_icon_ico/win_icon_32x32.png"
+    "branding/building_blocks/for_icon_ico/win_icon_48x48.png"
+    "branding/source/favicon.png"
+    "branding/source/mac_icon.png"
+    "branding/source/win_icon.png"
+    "branding/source/favicon.svg"
+    "branding/source/mac_icon.svg"
+    "branding/source/win_icon.svg"
+    "branding/source/artwork/favicon_transparent_square_blue-turqoise.psd"
+    "branding/source/artwork/logo_512.png"
+    "branding/source/artwork/logo_favicon_inkscape.svg"
+    "branding/source/artwork/logo_inkscape.svg"
+    "branding/source/artwork/logo_macos.psd"
+    "branding/source/artwork/logo_windows.psd"
+  )
+
+  # --- Get the list of files actually staged by the merge ---
+  staged_files=$(git diff --name-only --cached)
+
+  excluded_count=0
+  excluded_list=""
+
+  for staged_file in $staged_files; do
+    for protected in "${PROTECTED_FILES[@]}"; do
+      if [ "$staged_file" == "$protected" ]; then
+        git reset "$staged_file" > /dev/null 2>&1
+        git checkout "$staged_file" > /dev/null 2>&1
+        excluded_count=$((excluded_count + 1))
+        excluded_list="${excluded_list}        - ${staged_file}\n"
+        break
+      fi
+    done
+  done
+
+  # --- Print a clean summary ---
   echo
-  echo  "    *******************************************************************************"
-  echo  "    * Files expected to differ have been excluded from the sync.                  *"
-  echo  "    * Now review staged changes, and commit if there are no conflicts, then push. *"
-  echo  "    *******************************************************************************"
+  if [ "$excluded_count" -eq 0 ]; then
+    echo "     No protected files were affected by this sync."
+  else
+    echo "     ${excluded_count} protected file(s) were excluded from this sync:"
+    echo
+    echo -e "$excluded_list"
+    echo "     These files were reset to preserve this repo's versions."
+  fi
+  echo
+  echo "     *******************************************************************************"
+  echo "     * Now review staged changes, and commit if there are no conflicts, then push. *"
+  echo "     *******************************************************************************"
   echo
 }
 

--- a/linux/scripts/sync.bsh
+++ b/linux/scripts/sync.bsh
@@ -5,7 +5,7 @@ set -u
 
 doSync() {
   git fetch upstream main
-  git merge --no-log --no-ff --no-commit upstream/main > /dev/null || true
+  git merge --no-log --no-ff --no-commit upstream/main > /dev/null 2>&1 || true
 
   # --- Protected files: these should not be overwritten by the upstream merge ---
   PROTECTED_FILES=(

--- a/linux/scripts/sync.bsh
+++ b/linux/scripts/sync.bsh
@@ -60,7 +60,7 @@ doSync() {
     for protected in "${PROTECTED_FILES[@]}"; do
       if [ "$staged_file" == "$protected" ]; then
         git reset "$staged_file" > /dev/null 2>&1
-        git checkout "$staged_file" > /dev/null 2>&1
+        git checkout "$staged_file" > /dev/null 2>&1 || true
         excluded_count=$((excluded_count + 1))
         excluded_list="${excluded_list}        - ${staged_file}\n"
         break

--- a/macos/scripts/sync.zsh
+++ b/macos/scripts/sync.zsh
@@ -5,129 +5,90 @@ set -u # Zsh will want 1-based arrays, not 0-based.
 
 doSync() {
   git fetch upstream
-  git merge --no-log --no-ff --no-commit upstream/main
-  echo package-lock.json:
-  git reset package-lock.json
-  git checkout package-lock.json
-  echo globalBuildResources/favicon.ico:
-  git reset globalBuildResources/favicon.ico
-  git checkout globalBuildResources/favicon.ico
-  echo globalBuildResources/icon.icns:
-  git reset globalBuildResources/icon.icns
-  git checkout globalBuildResources/icon.icns
-  echo globalBuildResources/icon.ico:
-  git reset globalBuildResources/icon.ico
-  git checkout globalBuildResources/icon.ico
-  echo globalBuildResources/linux_icon.png:
-  git reset globalBuildResources/linux_icon.png
-  git checkout globalBuildResources/linux_icon.png
-  echo globalBuildResources/favicon.png:
-  git reset globalBuildResources/favicon.png
-  git checkout globalBuildResources/favicon.png
-  echo globalBuildResources/favicon@1.25x.png:
-  git reset globalBuildResources/favicon@1.25x.png
-  git checkout globalBuildResources/favicon@1.25x.png
-  echo globalBuildResources/favicon@1.5x.png:
-  git reset globalBuildResources/favicon@1.5x.png
-  git checkout globalBuildResources/favicon@1.5x.png
-  echo globalBuildResources/favicon@1.75x.png:
-  git reset globalBuildResources/favicon@1.75x.png
-  git checkout globalBuildResources/favicon@1.75x.png
-  echo globalBuildResources/favicon@2x.png:
-  git reset globalBuildResources/favicon@2x.png
-  git checkout globalBuildResources/favicon@2x.png
-  echo globalBuildResources/theme.json:
-  git reset globalBuildResources/theme.json
-  git checkout globalBuildResources/theme.json
-  echo branding/building_blocks/for_favicon_ico/favicon_16x16.png:
-  git reset branding/building_blocks/for_favicon_ico/favicon_16x16.png
-  git checkout branding/building_blocks/for_favicon_ico/favicon_16x16.png
-  echo branding/building_blocks/for_favicon_ico/favicon_32x32.png:
-  git reset branding/building_blocks/for_favicon_ico/favicon_32x32.png
-  git checkout branding/building_blocks/for_favicon_ico/favicon_32x32.png
-  echo branding/building_blocks/for_icon_icns/icon_128x128.png:
-  git reset branding/building_blocks/for_icon_icns/icon_128x128.png
-  git checkout branding/building_blocks/for_icon_icns/icon_128x128.png
-  echo branding/building_blocks/for_icon_icns/icon_128x128@2x.png:
-  git reset branding/building_blocks/for_icon_icns/icon_128x128@2x.png
-  git checkout branding/building_blocks/for_icon_icns/icon_128x128@2x.png
-  echo branding/building_blocks/for_icon_icns/icon_16x16.png:
-  git reset branding/building_blocks/for_icon_icns/icon_16x16.png
-  git checkout branding/building_blocks/for_icon_icns/icon_16x16.png
-  echo branding/building_blocks/for_icon_icns/icon_16x16@2x.png:
-  git reset branding/building_blocks/for_icon_icns/icon_16x16@2x.png
-  git checkout branding/building_blocks/for_icon_icns/icon_16x16@2x.png
-  echo branding/building_blocks/for_icon_icns/icon_256x256.png:
-  git reset branding/building_blocks/for_icon_icns/icon_256x256.png
-  git checkout branding/building_blocks/for_icon_icns/icon_256x256.png
-  echo branding/building_blocks/for_icon_icns/icon_256x256@2x.png:
-  git reset branding/building_blocks/for_icon_icns/icon_256x256@2x.png
-  git checkout branding/building_blocks/for_icon_icns/icon_256x256@2x.png
-  echo branding/building_blocks/for_icon_icns/icon_32x32.png:
-  git reset branding/building_blocks/for_icon_icns/icon_32x32.png
-  git checkout branding/building_blocks/for_icon_icns/icon_32x32.png
-  echo branding/building_blocks/for_icon_icns/icon_32x32@2x.png:
-  git reset branding/building_blocks/for_icon_icns/icon_32x32@2x.png
-  git checkout branding/building_blocks/for_icon_icns/icon_32x32@2x.png
-  echo branding/building_blocks/for_icon_icns/icon_512x512.png:
-  git reset branding/building_blocks/for_icon_icns/icon_512x512.png
-  git checkout branding/building_blocks/for_icon_icns/icon_512x512.png
-  echo branding/building_blocks/for_icon_icns/icon_512x512@2x.png:
-  git reset branding/building_blocks/for_icon_icns/icon_512x512@2x.png
-  git checkout branding/building_blocks/for_icon_icns/icon_512x512@2x.png
-  echo branding/building_blocks/for_icon_ico/win_icon_16x16.png:
-  git reset branding/building_blocks/for_icon_ico/win_icon_16x16.png
-  git checkout branding/building_blocks/for_icon_ico/win_icon_16x16.png
-  echo branding/building_blocks/for_icon_ico/win_icon_256x256.png:
-  git reset branding/building_blocks/for_icon_ico/win_icon_256x256.png
-  git checkout branding/building_blocks/for_icon_ico/win_icon_256x256.png
-  echo branding/building_blocks/for_icon_ico/win_icon_32x32.png:
-  git reset branding/building_blocks/for_icon_ico/win_icon_32x32.png
-  git checkout branding/building_blocks/for_icon_ico/win_icon_32x32.png
-  echo branding/building_blocks/for_icon_ico/win_icon_48x48.png:
-  git reset branding/building_blocks/for_icon_ico/win_icon_48x48.png
-  git checkout branding/building_blocks/for_icon_ico/win_icon_48x48.png
-  echo branding/source/favicon.png:
-  git reset branding/source/favicon.png
-  git checkout branding/source/favicon.png
-  echo branding/source/mac_icon.png:
-  git reset branding/source/mac_icon.png
-  git checkout branding/source/mac_icon.png
-  echo branding/source/win_icon.png:
-  git reset branding/source/win_icon.png
-  git checkout branding/source/win_icon.png
-  echo branding/source/favicon.svg:
-  git reset branding/source/favicon.svg
-  git checkout branding/source/favicon.svg
-  echo branding/source/mac_icon.svg:
-  git reset branding/source/mac_icon.svg
-  git checkout branding/source/mac_icon.svg
-  echo branding/source/win_icon.svg:
-  git reset branding/source/win_icon.svg
-  git checkout branding/source/win_icon.svg
-  echo branding/source/artwork/favicon_transparent_square_blue-turqoise.psd:
-  git reset branding/source/artwork/favicon_transparent_square_blue-turqoise.psd
-  git checkout branding/source/artwork/favicon_transparent_square_blue-turqoise.psd
-  echo branding/source/artwork/logo_512.png:
-  git reset branding/source/artwork/logo_512.png
-  git checkout branding/source/artwork/logo_512.png
-  echo branding/source/artwork/logo_favicon_inkscape.svg:
-  git reset branding/source/artwork/logo_favicon_inkscape.svg
-  git checkout branding/source/artwork/logo_favicon_inkscape.svg
-  echo branding/source/artwork/logo_inkscape.svg:
-  git reset branding/source/artwork/logo_inkscape.svg
-  git checkout branding/source/artwork/logo_inkscape.svg
-  echo branding/source/artwork/logo_macos.psd:
-  git reset branding/source/artwork/logo_macos.psd
-  git checkout branding/source/artwork/logo_macos.psd
-  echo branding/source/artwork/logo_windows.psd:
-  git reset branding/source/artwork/logo_windows.psd
-  git checkout branding/source/artwork/logo_windows.psd
+  git merge --no-log --no-ff --no-commit upstream/main || true
+
+  # --- Protected files: these should not be overwritten by the upstream merge ---
+  PROTECTED_FILES=(
+    "package-lock.json"
+    "globalBuildResources/favicon.ico"
+    "globalBuildResources/icon.icns"
+    "globalBuildResources/icon.ico"
+    "globalBuildResources/linux_icon.png"
+    "globalBuildResources/favicon.png"
+    "globalBuildResources/favicon@1.25x.png"
+    "globalBuildResources/favicon@1.5x.png"
+    "globalBuildResources/favicon@1.75x.png"
+    "globalBuildResources/favicon@2x.png"
+    "globalBuildResources/theme.json"
+    "branding/building_blocks/for_favicon_ico/favicon_16x16.png"
+    "branding/building_blocks/for_favicon_ico/favicon_32x32.png"
+    "branding/building_blocks/for_icon_icns/icon_128x128.png"
+    "branding/building_blocks/for_icon_icns/icon_128x128@2x.png"
+    "branding/building_blocks/for_icon_icns/icon_16x16.png"
+    "branding/building_blocks/for_icon_icns/icon_16x16@2x.png"
+    "branding/building_blocks/for_icon_icns/icon_256x256.png"
+    "branding/building_blocks/for_icon_icns/icon_256x256@2x.png"
+    "branding/building_blocks/for_icon_icns/icon_32x32.png"
+    "branding/building_blocks/for_icon_icns/icon_32x32@2x.png"
+    "branding/building_blocks/for_icon_icns/icon_512x512.png"
+    "branding/building_blocks/for_icon_icns/icon_512x512@2x.png"
+    "branding/building_blocks/for_icon_ico/win_icon_16x16.png"
+    "branding/building_blocks/for_icon_ico/win_icon_256x256.png"
+    "branding/building_blocks/for_icon_ico/win_icon_32x32.png"
+    "branding/building_blocks/for_icon_ico/win_icon_48x48.png"
+    "branding/source/favicon.png"
+    "branding/source/mac_icon.png"
+    "branding/source/win_icon.png"
+    "branding/source/favicon.svg"
+    "branding/source/mac_icon.svg"
+    "branding/source/win_icon.svg"
+    "branding/source/artwork/favicon_transparent_square_blue-turqoise.psd"
+    "branding/source/artwork/logo_512.png"
+    "branding/source/artwork/logo_favicon_inkscape.svg"
+    "branding/source/artwork/logo_inkscape.svg"
+    "branding/source/artwork/logo_macos.psd"
+    "branding/source/artwork/logo_windows.psd"
+  )
+
+  # --- Get the list of files actually staged by the merge ---
+  local staged_output
+  staged_output="$(git diff --name-only --cached)"
+  local staged_files=("${(@f)staged_output}")
+
+  local excluded_count=0
+  local excluded_list=()
+
+  for staged_file in "${staged_files[@]}"; do
+    # Skip empty lines (e.g., if nothing was staged)
+    [[ -z "$staged_file" ]] && continue
+    for protected in "${PROTECTED_FILES[@]}"; do
+      if [[ "$staged_file" == "$protected" ]]; then
+        git reset "$staged_file" > /dev/null 2>&1
+        git checkout "$staged_file" > /dev/null 2>&1
+        excluded_count=$((excluded_count + 1))
+        excluded_list+=("$staged_file")
+        break
+      fi
+    done
+  done
+
+  # --- Print a clean summary ---
   echo
-  echo  "    *******************************************************************************"
-  echo  "    * Files expected to differ have been excluded from the sync.                  *"
-  echo  "    * Now review staged changes, and commit if there are no conflicts, then push. *"
-  echo  "    *******************************************************************************"
+  if [[ "$excluded_count" -eq 0 ]]; then
+    echo "     No protected files were affected by this sync."
+  else
+    echo "     ${excluded_count} protected file(s) were excluded from this sync:"
+    echo
+    for item in "${excluded_list[@]}"; do
+      echo "        - ${item}"
+    done
+    echo
+    echo "     These files were reset to preserve this repo's versions."
+  fi
+  echo
+  echo "     *******************************************************************************"
+  echo "     * Now review staged changes, and commit if there are no conflicts, then push. *"
+  echo "     *******************************************************************************"
   echo
 }
 

--- a/macos/scripts/sync.zsh
+++ b/macos/scripts/sync.zsh
@@ -4,8 +4,8 @@ set -e
 set -u # Zsh will want 1-based arrays, not 0-based.
 
 doSync() {
-  git fetch upstream
-  git merge --no-log --no-ff --no-commit upstream/main || true
+  git fetch upstream main
+  git merge --no-log --no-ff --no-commit upstream/main > /dev/null || true
 
   # --- Protected files: these should not be overwritten by the upstream merge ---
   PROTECTED_FILES=(

--- a/macos/scripts/sync.zsh
+++ b/macos/scripts/sync.zsh
@@ -64,7 +64,7 @@ doSync() {
     for protected in "${PROTECTED_FILES[@]}"; do
       if [[ "$staged_file" == "$protected" ]]; then
         git reset "$staged_file" > /dev/null 2>&1
-        git checkout "$staged_file" > /dev/null 2>&1
+        git checkout "$staged_file" > /dev/null 2>&1 || true
         excluded_count=$((excluded_count + 1))
         excluded_list+=("$staged_file")
         break

--- a/macos/scripts/sync.zsh
+++ b/macos/scripts/sync.zsh
@@ -5,7 +5,7 @@ set -u # Zsh will want 1-based arrays, not 0-based.
 
 doSync() {
   git fetch upstream main
-  git merge --no-log --no-ff --no-commit upstream/main > /dev/null || true
+  git merge --no-log --no-ff --no-commit upstream/main > /dev/null 2>&1 || true
 
   # --- Protected files: these should not be overwritten by the upstream merge ---
   PROTECTED_FILES=(

--- a/windows/scripts/sync.bat
+++ b/windows/scripts/sync.bat
@@ -102,131 +102,94 @@ if "%upstreamtest%"=="different_if_not_changed" (
 :sync
 git fetch upstream
 git merge --no-log --no-ff --no-commit upstream/main
-echo package-lock.json:
-git reset package-lock.json
-git checkout package-lock.json
-echo globalBuildResources\favicon.ico:
-git reset globalBuildResources\favicon.ico
-git checkout globalBuildResources\favicon.ico
-echo globalBuildResources\icon.icns:
-git reset globalBuildResources\icon.icns
-git checkout globalBuildResources\icon.icns
-echo globalBuildResources\icon.ico:
-git reset globalBuildResources\icon.ico
-git checkout globalBuildResources\icon.ico
-echo globalBuildResources\linux_icon.png:
-git reset globalBuildResources\linux_icon.png
-git checkout globalBuildResources\linux_icon.png
-echo globalBuildResources\favicon.png:
-git reset globalBuildResources\favicon.png
-git checkout globalBuildResources\favicon.png
-echo globalBuildResources\favicon@1.25x.png:
-git reset globalBuildResources\favicon@1.25x.png
-git checkout globalBuildResources\favicon@1.25x.png
-echo globalBuildResources\favicon@1.5x.png:
-git reset globalBuildResources\favicon@1.5x.png
-git checkout globalBuildResources\favicon@1.5x.png
-echo globalBuildResources\favicon@1.75x.png:
-git reset globalBuildResources\favicon@1.75x.png
-git checkout globalBuildResources\favicon@1.75x.png
-echo globalBuildResources\favicon@2x.png:
-git reset globalBuildResources\favicon@2x.png
-git checkout globalBuildResources\favicon@2x.png
-echo globalBuildResources\theme.json:
-git reset globalBuildResources\theme.json
-git checkout globalBuildResources\theme.json
-echo branding\building_blocks\for_favicon_ico\favicon_16x16.png:
-git reset branding\building_blocks\for_favicon_ico\favicon_16x16.png
-git checkout branding\building_blocks\for_favicon_ico\favicon_16x16.png
-echo branding\building_blocks\for_favicon_ico\favicon_32x32.png:
-git reset branding\building_blocks\for_favicon_ico\favicon_32x32.png
-git checkout branding\building_blocks\for_favicon_ico\favicon_32x32.png
-echo branding\building_blocks\for_icon_icns\icon_128x128.png:
-git reset branding\building_blocks\for_icon_icns\icon_128x128.png
-git checkout branding\building_blocks\for_icon_icns\icon_128x128.png
-echo branding\building_blocks\for_icon_icns\icon_128x128@2x.png:
-git reset branding\building_blocks\for_icon_icns\icon_128x128@2x.png
-git checkout branding\building_blocks\for_icon_icns\icon_128x128@2x.png
-echo branding\building_blocks\for_icon_icns\icon_16x16.png:
-git reset branding\building_blocks\for_icon_icns\icon_16x16.png
-git checkout branding\building_blocks\for_icon_icns\icon_16x16.png
-echo branding\building_blocks\for_icon_icns\icon_16x16@2x.png:
-git reset branding\building_blocks\for_icon_icns\icon_16x16@2x.png
-git checkout branding\building_blocks\for_icon_icns\icon_16x16@2x.png
-echo branding\building_blocks\for_icon_icns\icon_256x256.png:
-git reset branding\building_blocks\for_icon_icns\icon_256x256.png
-git checkout branding\building_blocks\for_icon_icns\icon_256x256.png
-echo branding\building_blocks\for_icon_icns\icon_256x256@2x.png:
-git reset branding\building_blocks\for_icon_icns\icon_256x256@2x.png
-git checkout branding\building_blocks\for_icon_icns\icon_256x256@2x.png
-echo branding\building_blocks\for_icon_icns\icon_32x32.png:
-git reset branding\building_blocks\for_icon_icns\icon_32x32.png
-git checkout branding\building_blocks\for_icon_icns\icon_32x32.png
-echo branding\building_blocks\for_icon_icns\icon_32x32@2x.png:
-git reset branding\building_blocks\for_icon_icns\icon_32x32@2x.png
-git checkout branding\building_blocks\for_icon_icns\icon_32x32@2x.png
-echo branding\building_blocks\for_icon_icns\icon_512x512.png:
-git reset branding\building_blocks\for_icon_icns\icon_512x512.png
-git checkout branding\building_blocks\for_icon_icns\icon_512x512.png
-echo branding\building_blocks\for_icon_icns\icon_512x512@2x.png:
-git reset branding\building_blocks\for_icon_icns\icon_512x512@2x.png
-git checkout branding\building_blocks\for_icon_icns\icon_512x512@2x.png
-echo branding\building_blocks\for_icon_ico\win_icon_16x16.png:
-git reset branding\building_blocks\for_icon_ico\win_icon_16x16.png
-git checkout branding\building_blocks\for_icon_ico\win_icon_16x16.png
-echo branding\building_blocks\for_icon_ico\win_icon_256x256.png:
-git reset branding\building_blocks\for_icon_ico\win_icon_256x256.png
-git checkout branding\building_blocks\for_icon_ico\win_icon_256x256.png
-echo branding\building_blocks\for_icon_ico\win_icon_32x32.png:
-git reset branding\building_blocks\for_icon_ico\win_icon_32x32.png
-git checkout branding\building_blocks\for_icon_ico\win_icon_32x32.png
-echo branding\building_blocks\for_icon_ico\win_icon_48x48.png:
-git reset branding\building_blocks\for_icon_ico\win_icon_48x48.png
-git checkout branding\building_blocks\for_icon_ico\win_icon_48x48.png
-echo branding\source\favicon.png:
-git reset branding\source\favicon.png
-git checkout branding\source\favicon.png
-echo branding\source\mac_icon.png:
-git reset branding\source\mac_icon.png
-git checkout branding\source\mac_icon.png
-echo branding\source\win_icon.png:
-git reset branding\source\win_icon.png
-git checkout branding\source\win_icon.png
-echo branding\source\favicon.svg:
-git reset branding\source\favicon.svg
-git checkout branding\source\favicon.svg
-echo branding\source\mac_icon.svg:
-git reset branding\source\mac_icon.svg
-git checkout branding\source\mac_icon.svg
-echo branding\source\win_icon.svg:
-git reset branding\source\win_icon.svg
-git checkout branding\source\win_icon.svg
-echo branding\source\artwork\favicon_transparent_square_blue-turqoise.psd:
-git reset branding\source\artwork\favicon_transparent_square_blue-turqoise.psd
-git checkout branding\source\artwork\favicon_transparent_square_blue-turqoise.psd
-echo branding\source\artwork\logo_512.png:
-git reset branding\source\artwork\logo_512.png
-git checkout branding\source\artwork\logo_512.png
-echo branding\source\artwork\logo_favicon_inkscape.svg:
-git reset branding\source\artwork\logo_favicon_inkscape.svg
-git checkout branding\source\artwork\logo_favicon_inkscape.svg
-echo branding\source\artwork\logo_inkscape.svg:
-git reset branding\source\artwork\logo_inkscape.svg
-git checkout branding\source\artwork\logo_inkscape.svg
-echo branding\source\artwork\logo_macos.psd:
-git reset branding\source\artwork\logo_macos.psd
-git checkout branding\source\artwork\logo_macos.psd
-echo branding\source\artwork\logo_windows.psd:
-git reset branding\source\artwork\logo_windows.psd
-git checkout branding\source\artwork\logo_windows.psd
+
+REM --- Build the list of files we want to protect from the merge ---
+SET "PROTECTED_FILES=package-lock.json"
+SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\favicon.ico"
+SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\icon.icns"
+SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\icon.ico"
+SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\linux_icon.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\favicon.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\favicon@1.25x.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\favicon@1.5x.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\favicon@1.75x.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\favicon@2x.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\theme.json"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_favicon_ico\favicon_16x16.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_favicon_ico\favicon_32x32.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_128x128.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_128x128@2x.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_16x16.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_16x16@2x.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_256x256.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_256x256@2x.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_32x32.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_32x32@2x.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_512x512.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_512x512@2x.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_ico\win_icon_16x16.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_ico\win_icon_256x256.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_ico\win_icon_32x32.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_ico\win_icon_48x48.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\favicon.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\mac_icon.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\win_icon.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\favicon.svg"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\mac_icon.svg"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\win_icon.svg"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\artwork\favicon_transparent_square_blue-turqoise.psd"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\artwork\logo_512.png"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\artwork\logo_favicon_inkscape.svg"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\artwork\logo_inkscape.svg"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\artwork\logo_macos.psd"
+SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\artwork\logo_windows.psd"
+
+REM --- Get the list of files actually staged by the merge ---
+SET "excluded_count=0"
+SET "excluded_list="
+
+REM --- For each staged file, check if it's in our protected list ---
+FOR /F "tokens=* USEBACKQ" %%S IN (`git diff --name-only --cached`) DO (
+  REM git outputs forward slashes; convert to backslashes for comparison
+  SET "staged_file=%%S"
+  SET "staged_file=!staged_file:/=\!"
+  SET "was_protected=0"
+  FOR %%P IN (%PROTECTED_FILES%) DO (
+    IF /I "!staged_file!"=="%%P" (
+      SET "was_protected=1"
+    )
+  )
+  IF "!was_protected!"=="1" (
+    git reset "%%S" >nul 2>&1
+    git checkout "%%S" >nul 2>&1
+    SET /a excluded_count=!excluded_count!+1
+    SET "excluded_list=!excluded_list!      - !staged_file!!LF!"
+  )
+)
+
+REM --- Print a clean summary ---
+echo.
+IF !excluded_count! EQU 0 (
+  echo      No protected files were affected by this sync.
+) ELSE (
+  echo      !excluded_count! protected file(s) were excluded from this sync:
+  echo.
+  REM Print each excluded file
+  FOR /F "tokens=* USEBACKQ" %%S IN (`git diff --name-only`) DO (
+    SET "unstaged=%%S"
+    SET "unstaged=!unstaged:/=\!"
+    FOR %%P IN (%PROTECTED_FILES%) DO (
+      IF /I "!unstaged!"=="%%P" (
+        echo        - !unstaged!
+      )
+    )
+  )
+  echo.
+  echo      These files were reset to preserve this repo's versions.
+)
 echo.
 echo      *******************************************************************************
-echo      * Files expected to differ have been excluded from the sync.                  *
 echo      * Now review staged changes, and commit if there are no conflicts, then push. *
 echo      *******************************************************************************
 echo.
 exit /b
-
-:end
-cd windows\scripts\
-ENDLOCAL

--- a/windows/scripts/sync.bat
+++ b/windows/scripts/sync.bat
@@ -6,7 +6,7 @@ REM To pre-confirm the server is off, so as to not be asked.
 
 echo.
 :choice
-IF "%~1"=="-p" (
+IF "%~1" == "-p" (
   goto :yes
 ) ELSE (
   set /P "c=Is the latest already pulled? [Y/n]: "
@@ -55,7 +55,7 @@ set "origintest=good_if_not_changed"
 set "upstreamtest=different_if_not_changed"
 for /l %%b in (1,1,%countb%) do (
   REM Don't proceed if the origin is the intended upstream.
-  IF "!varb%%b!"=="remote.origin.url=https://github.com/pankosmia/desktop-app-template.git" (
+  IF "!varb%%b!" == "remote.origin.url=https://github.com/pankosmia/desktop-app-template.git" (
     set "origintest=stop_because_is_set_to_desired_upstream"
     echo.
     echo origin is set to https://github.com/pankosmia/desktop-app-template.git
@@ -67,9 +67,9 @@ for /l %%b in (1,1,%countb%) do (
   )
   REM This assumes the origin record will always be returned on an earlier line that the upstream record.
   REM Proceed if the origin is set.
-  IF "%origintest%"=="good_if_not_changed" (
+  IF "%origintest%" == "good_if_not_changed" (
       REM Proceed if the upstream is already set as expected.
-    IF "!varb%%b!"=="remote.upstream.url=https://github.com/pankosmia/desktop-app-template.git" (
+    IF "!varb%%b!" == "remote.upstream.url=https://github.com/pankosmia/desktop-app-template.git" (
       set "upstreamtest=as_expected"
       echo upstream is confirmed as set to https://github.com/pankosmia/desktop-app-template.git
       set up=%%b
@@ -80,7 +80,7 @@ for /l %%b in (1,1,%countb%) do (
 )
 REM This assumes the origin record will always be returned on an earlier line that the upstream record.
 REM Proceed if the origin is set.
-if "%origintest%"=="good_if_not_changed" (
+if "%origintest%" == "good_if_not_changed" (
   REM Set the upstream and proceed if it is not yet set.
   if not defined vara2 (
     git remote add upstream https://github.com/pankosmia/desktop-app-template.git
@@ -91,7 +91,7 @@ if "%origintest%"=="good_if_not_changed" (
   )
 )
 REM Don't proceed if the upstream is set elsewhere.
-if "%upstreamtest%"=="different_if_not_changed" (
+if "%upstreamtest%" == "different_if_not_changed" (
   echo.
   echo The upstream is set to: !varb%up%!
   echo However, this script is written for an upstream that is set to https://github.com/pankosmia/desktop-app-template.git
@@ -100,67 +100,68 @@ if "%upstreamtest%"=="different_if_not_changed" (
 )
 
 :sync
+git fetch upstream main
+git merge --no-log --no-ff --no-commit upstream/main > nul 2>&1
+
 del "%TEMP%\sync_excluded.txt" >nul 2>&1
-git fetch upstream
-git merge --no-log --no-ff --no-commit upstream/main
+del "%TEMP%\sync_protected.txt" >nul 2>&1
 
-REM --- Build the list of files we want to protect from the merge ---
-SET "PROTECTED_FILES=package-lock.json"
-SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\favicon.ico"
-SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\icon.icns"
-SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\icon.ico"
-SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\linux_icon.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\favicon.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\favicon@1.25x.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\favicon@1.5x.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\favicon@1.75x.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\favicon@2x.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% globalBuildResources\theme.json"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_favicon_ico\favicon_16x16.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_favicon_ico\favicon_32x32.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_128x128.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_128x128@2x.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_16x16.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_16x16@2x.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_256x256.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_256x256@2x.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_32x32.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_32x32@2x.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_512x512.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_icns\icon_512x512@2x.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_ico\win_icon_16x16.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_ico\win_icon_256x256.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_ico\win_icon_32x32.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\building_blocks\for_icon_ico\win_icon_48x48.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\favicon.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\mac_icon.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\win_icon.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\favicon.svg"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\mac_icon.svg"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\win_icon.svg"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\artwork\favicon_transparent_square_blue-turqoise.psd"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\artwork\logo_512.png"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\artwork\logo_favicon_inkscape.svg"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\artwork\logo_inkscape.svg"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\artwork\logo_macos.psd"
-SET "PROTECTED_FILES=%PROTECTED_FILES% branding\source\artwork\logo_windows.psd"
+REM --- Write protected files list to a temp file (avoids @ parsing issues) ---
+(
+  echo package-lock.json
+  echo globalBuildResources\favicon.ico
+  echo globalBuildResources\icon.icns
+  echo globalBuildResources\icon.ico
+  echo globalBuildResources\linux_icon.png
+  echo globalBuildResources\favicon.png
+  echo globalBuildResources\favicon@1.25x.png
+  echo globalBuildResources\favicon@1.5x.png
+  echo globalBuildResources\favicon@1.75x.png
+  echo globalBuildResources\favicon@2x.png
+  echo globalBuildResources\theme.json
+  echo branding\building_blocks\for_favicon_ico\favicon_16x16.png
+  echo branding\building_blocks\for_favicon_ico\favicon_32x32.png
+  echo branding\building_blocks\for_icon_icns\icon_128x128.png
+  echo branding\building_blocks\for_icon_icns\icon_128x128@2x.png
+  echo branding\building_blocks\for_icon_icns\icon_16x16.png
+  echo branding\building_blocks\for_icon_icns\icon_16x16@2x.png
+  echo branding\building_blocks\for_icon_icns\icon_256x256.png
+  echo branding\building_blocks\for_icon_icns\icon_256x256@2x.png
+  echo branding\building_blocks\for_icon_icns\icon_32x32.png
+  echo branding\building_blocks\for_icon_icns\icon_32x32@2x.png
+  echo branding\building_blocks\for_icon_icns\icon_512x512.png
+  echo branding\building_blocks\for_icon_icns\icon_512x512@2x.png
+  echo branding\building_blocks\for_icon_ico\win_icon_16x16.png
+  echo branding\building_blocks\for_icon_ico\win_icon_256x256.png
+  echo branding\building_blocks\for_icon_ico\win_icon_32x32.png
+  echo branding\building_blocks\for_icon_ico\win_icon_48x48.png
+  echo branding\source\favicon.png
+  echo branding\source\mac_icon.png
+  echo branding\source\win_icon.png
+  echo branding\source\favicon.svg
+  echo branding\source\mac_icon.svg
+  echo branding\source\win_icon.svg
+  echo branding\source\artwork\favicon_transparent_square_blue-turqoise.psd
+  echo branding\source\artwork\logo_512.png
+  echo branding\source\artwork\logo_favicon_inkscape.svg
+  echo branding\source\artwork\logo_inkscape.svg
+  echo branding\source\artwork\logo_macos.psd
+  echo branding\source\artwork\logo_windows.psd
+) > "%TEMP%\sync_protected.txt"
 
-REM --- Get the list of files actually staged by the merge ---
 SET "excluded_count=0"
-SET "excluded_list="
 
-REM --- For each staged file, check if it's in our protected list ---
+REM --- For each staged file, check if it's in the protected list ---
 FOR /F "tokens=* USEBACKQ" %%S IN (`git diff --name-only --cached`) DO (
-  REM git outputs forward slashes; convert to backslashes for comparison
   SET "staged_file=%%S"
   SET "staged_file=!staged_file:/=\!"
   SET "was_protected=0"
-  FOR %%P IN (%PROTECTED_FILES%) DO (
-    IF /I "!staged_file!"=="%%P" (
+  FOR /F "usebackq tokens=*" %%P IN ("%TEMP%\sync_protected.txt") DO (
+    IF /I "!staged_file!" == "%%P" (
       SET "was_protected=1"
     )
   )
-  IF "!was_protected!"=="1" (
+  IF "!was_protected!" == "1" (
     git reset "%%S" >nul 2>&1
     git checkout "%%S" >nul 2>&1
     SET /a excluded_count=!excluded_count!+1
@@ -168,12 +169,12 @@ FOR /F "tokens=* USEBACKQ" %%S IN (`git diff --name-only --cached`) DO (
   )
 )
 
+del "%TEMP%\sync_protected.txt" >nul 2>&1
+
 REM --- Print a clean summary ---
 echo.
-IF !excluded_count! EQU 0 (
-  echo      No protected files were affected by this sync.
-) ELSE (
-  echo      !excluded_count! protected file(s) were excluded from this sync:
+echo      !excluded_count! protected file(s) were excluded from this sync.
+IF EXIST "%TEMP%\sync_excluded.txt" (
   echo.
   type "%TEMP%\sync_excluded.txt"
   del "%TEMP%\sync_excluded.txt" >nul 2>&1
@@ -186,3 +187,5 @@ echo      * Now review staged changes, and commit if there are no conflicts, the
 echo      *******************************************************************************
 echo.
 exit /b
+
+:end

--- a/windows/scripts/sync.bat
+++ b/windows/scripts/sync.bat
@@ -100,6 +100,7 @@ if "%upstreamtest%"=="different_if_not_changed" (
 )
 
 :sync
+del "%TEMP%\sync_excluded.txt" >nul 2>&1
 git fetch upstream
 git merge --no-log --no-ff --no-commit upstream/main
 
@@ -163,7 +164,7 @@ FOR /F "tokens=* USEBACKQ" %%S IN (`git diff --name-only --cached`) DO (
     git reset "%%S" >nul 2>&1
     git checkout "%%S" >nul 2>&1
     SET /a excluded_count=!excluded_count!+1
-    SET "excluded_list=!excluded_list!      - !staged_file!!LF!"
+    echo        - !staged_file!>> "%TEMP%\sync_excluded.txt"
   )
 )
 
@@ -174,16 +175,8 @@ IF !excluded_count! EQU 0 (
 ) ELSE (
   echo      !excluded_count! protected file(s) were excluded from this sync:
   echo.
-  REM Print each excluded file
-  FOR /F "tokens=* USEBACKQ" %%S IN (`git diff --name-only`) DO (
-    SET "unstaged=%%S"
-    SET "unstaged=!unstaged:/=\!"
-    FOR %%P IN (%PROTECTED_FILES%) DO (
-      IF /I "!unstaged!"=="%%P" (
-        echo        - !unstaged!
-      )
-    )
-  )
+  type "%TEMP%\sync_excluded.txt"
+  del "%TEMP%\sync_excluded.txt" >nul 2>&1
   echo.
   echo      These files were reset to preserve this repo's versions.
 )


### PR DESCRIPTION
# Friendlier Sync

Improvements:
- Only the main branch of the upstream is fetched
- No more TLDR string of git checkout / git reset onscreen messages
- An actual git checkout / git reset now only happens when a protected file is included in the merge.
  - When it does, the output is silently swallowed.
  - This also silently swallows any git reset "fatal errors" on merged protected files with no prior version to restore.
- A summary of any protect files that are reset is shown, as follows:
`${excluded_count} protected file(s) were excluded from this sync:`
`(and then the files are listed)`
`  These files were reset to preserve this repo's versions.`
`*******************************************************************************`
`* Now review staged changes, and commit if there are no conflicts, then push. *`
`*******************************************************************************`
 
Here is the onscreen message of a Linux or MacOS sync when no protected files are involved in the merge:
<img width="692" height="280" alt="image" src="https://github.com/user-attachments/assets/4cc2e95c-1ffc-455a-b091-0cb3ca43fad8" />

The Windows result provides the same info. Technically It says `0 protected file(s) were excluded from this sync.`, which is the same diff.