### PR TITLE
Local build clients script updates

### DIFF
--- a/.github/workflows/linux-build-steps.yml
+++ b/.github/workflows/linux-build-steps.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Build ${{ inputs.branches }} clients
         working-directory: ./linux/scripts
-        run: ./build_clients.bsh "$BRANCHES"
+        run: ./build_clients.bsh -f "$BRANCHES"
 
       - name: Build ${{ inputs.branches }} DEBUG server and assemble build environment without asking if the server is off
         working-directory: ./linux/scripts

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Build ${{ inputs.branches }} clients
         working-directory: ./macos/scripts
-        run: ./build_clients.zsh "$BRANCHES"
+        run: ./build_clients.zsh -f "$BRANCHES"
 
       - name: Build ${{ inputs.branches }} DEBUG server and assemble build environment without asking if the server is off
         working-directory: ./macos/scripts

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -120,7 +120,7 @@ jobs:
       # Install and build clients
       - name: Build ${{ inputs.branches }} clients
         working-directory: .\windows\scripts
-        run: .\build_clients.bat "$BRANCHES"
+        run: .\build_clients.bat -f "$BRANCHES"
 
       # Build DEBUG server and assemble build environment without asking if the server is off
       - name: Run ${{ inputs.branches }} DEBUG server and assemble build environment without asking if the server is off

--- a/linux/scripts/build_clients.bsh
+++ b/linux/scripts/build_clients.bsh
@@ -1,26 +1,39 @@
 #!/usr/bin/env bash
 
 # Run from: pankosmia/<repo-name>/linux/scripts
+
 # Usage:
-#   ./build_clients.bsh [branch] [-d]
+#   ./build_clients.bsh [branch] [fallback_tier] [-d] [-f]
+#     The -d argument means to delete past logs without asking
+#     The -f argument means only fresh clones are being built, so pulling is skipped.
+#     The first non-flag argument is the branch name (default: main)
+#     The second non-flag argument is the fallback tier: dev, qa, or main (default: same as branch)
+
 # Examples:
-#   ./build_clients.bsh              # defaults to "main"
-#   ./build_clients.bsh dev          # tries dev → qa → main
-#   ./build_clients.bsh qa -d        # tries qa → main, deletes past logs
-#   ./build_clients.bsh -d dev       # same as above, flags and branch in any order
+#   ./build_clients.bsh                        # defaults to "main"
+#   ./build_clients.bsh dev                    # tries dev → qa → main
+#   ./build_clients.bsh my-branch dev          # tries my-branch → dev → qa → main
+#   ./build_clients.bsh my-branch qa -d        # tries my-branch → qa → main, deletes past logs
+#   ./build_clients.bsh -f -d dev              # fresh clone (skips pulling), delete logs, branch=dev → qa → main
 
 source ../../app_config.env
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# --- parse args (-d flag and optional branch) ---
+# --- parse args ---
 deleteLogs="-no"
+FRESH_CLONE=""
 BRANCH=""
+FALLBACK_TIER=""
 while [ $# -gt 0 ]; do
   if [ "$1" = "-d" ]; then
     deleteLogs="-d"
+  elif [ "$1" = "-f" ]; then
+    FRESH_CLONE=1
   elif [ -z "$BRANCH" ]; then
     BRANCH="$1"
+  elif [ -z "$FALLBACK_TIER" ]; then
+    FALLBACK_TIER="$1"
   fi
   shift
 done
@@ -29,6 +42,22 @@ done
 if [ -z "$BRANCH" ]; then
   BRANCH="main"
 fi
+
+# If no fallback tier specified, derive from the branch itself
+if [ -z "$FALLBACK_TIER" ]; then
+  case "${BRANCH,,}" in
+    dev) FALLBACK_TIER="dev" ;;
+    qa)  FALLBACK_TIER="qa" ;;
+    *)   FALLBACK_TIER="main" ;;
+  esac
+fi
+
+# Normalize fallback tier: anything other than dev or qa becomes main
+case "${FALLBACK_TIER,,}" in
+  dev) FALLBACK_TIER="dev" ;;
+  qa)  FALLBACK_TIER="qa" ;;
+  *)   FALLBACK_TIER="main" ;;
+esac
 
 # --- delete past logs (prompt unless -d) ---
 if ls "${SCRIPT_DIR}"/build_clients_*.log >/dev/null 2>&1; then
@@ -56,6 +85,8 @@ echo "===== Build started $(date) =====" > "$LOG"
 
 FAILCOUNT=0
 FAILS=()
+SKIPCOUNT=0
+SKIPS=()
 
 log() {
   echo "$*"
@@ -72,6 +103,11 @@ markfail() {
   FAILS+=("[$1] $2 :: $3")
 }
 
+markskip() {
+  SKIPCOUNT=$((SKIPCOUNT + 1))
+  SKIPS+=("[$1] $2 ($3): $4")
+}
+
 # --- checkout with fallback logic ---
 checkout_branch() {
   local cb_type="$1"
@@ -79,35 +115,91 @@ checkout_branch() {
 
   log "> git checkout $BRANCH..."
   if run git checkout "$BRANCH"; then
+    CHECKED_OUT_BRANCH="$BRANCH"
     return
   fi
 
-  # Branch didn't exist — apply fallback logic
-  if [ "${BRANCH,,}" = "dev" ]; then
+  # Branch didn't exist -- apply fallback based on FALLBACK_TIER
+  if [ "$FALLBACK_TIER" = "dev" ]; then
+    if [ "${BRANCH,,}" != "dev" ]; then
+      log "> Branch \"$BRANCH\" not found, trying \"dev\"..."
+      if run git checkout dev; then
+        CHECKED_OUT_BRANCH="dev"
+        return
+      fi
+    fi
+
     log "> Branch \"dev\" not found, trying \"qa\"..."
     if run git checkout qa; then
+      CHECKED_OUT_BRANCH="qa"
       return
     fi
+
     log "> Branch \"qa\" not found, falling back to \"main\"..."
     if ! run git checkout main; then
-      markfail "$cb_type" "$cb_repo" "git checkout main (fallback from dev)"
+      markfail "$cb_type" "$cb_repo" "git checkout main (fallback from $BRANCH)"
     fi
+    CHECKED_OUT_BRANCH="main"
     return
   fi
 
-  if [ "${BRANCH,,}" = "qa" ]; then
+  if [ "$FALLBACK_TIER" = "qa" ]; then
+    if [ "${BRANCH,,}" != "qa" ]; then
+      log "> Branch \"$BRANCH\" not found, trying \"qa\"..."
+      if run git checkout qa; then
+        CHECKED_OUT_BRANCH="qa"
+        return
+      fi
+    fi
+
     log "> Branch \"qa\" not found, falling back to \"main\"..."
     if ! run git checkout main; then
-      markfail "$cb_type" "$cb_repo" "git checkout main (fallback from qa)"
+      markfail "$cb_type" "$cb_repo" "git checkout main (fallback from $BRANCH)"
     fi
+    CHECKED_OUT_BRANCH="main"
     return
   fi
 
-  # Any other branch — fall back to main
   log "> Branch \"$BRANCH\" not found, falling back to \"main\"..."
   if ! run git checkout main; then
     markfail "$cb_type" "$cb_repo" "git checkout main (fallback from $BRANCH)"
   fi
+  CHECKED_OUT_BRANCH="main"
+}
+
+# --- pull logic ---
+safe_pull() {
+  local sp_type="$1"
+  local sp_repo="$2"
+
+  if [ -n "$FRESH_CLONE" ]; then
+    log "> Skipping pull -- -f flag set, 'fresh' clone, no pull"
+    markskip "$sp_type" "$sp_repo" "$CHECKED_OUT_BRANCH" "-f flag set, 'fresh' clone, no pull"
+    return
+  fi
+
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    log "> Skipping pull -- uncommitted local changes detected on \"$CHECKED_OUT_BRANCH\", no pull"
+    markskip "$sp_type" "$sp_repo" "$CHECKED_OUT_BRANCH" "uncommitted local changes, no pull"
+    return
+  fi
+
+  if ! git rev-parse --verify "origin/$CHECKED_OUT_BRANCH" >/dev/null 2>&1; then
+    log "> Skipping pull -- origin/$CHECKED_OUT_BRANCH does not exist, no pull"
+    markskip "$sp_type" "$sp_repo" "$CHECKED_OUT_BRANCH" "origin/$CHECKED_OUT_BRANCH does not exist, no pull"
+    return
+  fi
+
+  local local_ahead
+  local_ahead=$(git rev-list "origin/$CHECKED_OUT_BRANCH..HEAD" --count 2>/dev/null)
+  if [ "$local_ahead" -gt 0 ] 2>/dev/null; then
+    log "> Skipping pull -- \"$CHECKED_OUT_BRANCH\" has $local_ahead unpushed commit(s), no pull"
+    markskip "$sp_type" "$sp_repo" "$CHECKED_OUT_BRANCH" "$local_ahead unpushed commit(s), no pull"
+    return
+  fi
+
+  log "> git pull origin $CHECKED_OUT_BRANCH..."
+  if ! run git pull origin "$CHECKED_OUT_BRANCH"; then markfail "$sp_type" "$sp_repo" "git pull origin $CHECKED_OUT_BRANCH"; fi
 }
 
 # --- original counting approach ---
@@ -131,9 +223,7 @@ for ((i=1;i<=count;i++)); do
     else
       cd "$asset"
       checkout_branch "ASSET" "$asset"
-
-      log "> git pull..."
-      if ! run git pull; then markfail "ASSET" "$asset" "git pull"; fi
+      safe_pull "ASSET" "$asset"
 
       log "################################ END Asset $i: $asset ################################"
       log
@@ -156,9 +246,7 @@ for ((i=1;i<=count;i++)); do
     else
       cd "$client"
       checkout_branch "CLIENT" "$client"
-
-      log "> git pull..."
-      if ! run git pull; then markfail "CLIENT" "$client" "git pull"; fi
+      safe_pull "CLIENT" "$client"
 
       log "> npm ci..."
       if ! run npm ci; then markfail "CLIENT" "$client" "npm ci"; fi
@@ -183,11 +271,22 @@ if [ "$FAILCOUNT" -eq 0 ]; then
 else
   echo "Failed steps: $FAILCOUNT"
   for f in "${FAILS[@]}"; do
-    echo "$f"
+    echo "  $f"
+  done
+fi
+if [ "$SKIPCOUNT" -gt 0 ]; then
+  echo
+  echo "Skipped pulls: $SKIPCOUNT"
+  for s in "${SKIPS[@]}"; do
+    echo "  $s"
   done
 fi
 echo
-echo "Full log: \"$LOG\""
+if /i "%GITHUB_ACTIONS%"=="true" 2>/dev/null; then
+  echo "Full log: scroll up in the \"Run build_clients.bsh\" step output above."
+else
+  echo "Full log: \"$LOG\""
+fi
 echo "==========================================================================="
 
 if [ "$FAILCOUNT" -gt 0 ]; then

--- a/macos/scripts/build_clients.zsh
+++ b/macos/scripts/build_clients.zsh
@@ -1,26 +1,39 @@
 #!/usr/bin/env zsh
 
 # Run from: pankosmia/<repo-name>/linux/scripts
+
 # Usage:
-#   ./build_clients.zsh [branch] [-d]
+#   ./build_clients.zsh [branch] [fallback_tier] [-d] [-f]
+#     The -d argument means to delete past logs without asking
+#     The -f argument means only fresh clones are being built, so pulling is skipped.
+#     The first non-flag argument is the branch name (default: main)
+#     The second non-flag argument is the fallback tier: dev, qa, or main (default: same as branch)
+
 # Examples:
-#   ./build_clients.zsh              # defaults to "main"
-#   ./build_clients.zsh dev          # tries dev → qa → main
-#   ./build_clients.zsh qa -d        # tries qa → main, deletes past logs
-#   ./build_clients.zsh -d dev       # same as above, flags and branch in any order
+#   ./build_clients.zsh                        # defaults to "main"
+#   ./build_clients.zsh dev                    # tries dev → qa → main
+#   ./build_clients.zsh my-branch dev         # tries my-branch → dev → qa → main
+#   ./build_clients.zsh my-branch qa -d       # tries my-branch → qa → main, deletes past logs
+#   ./build_clients.zsh -f -d dev              # fresh clone (skips pulling), delete logs, branch=dev → qa → main
 
 source ../../app_config.env
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# --- parse args (-d flag and optional branch) ---
+# --- parse args ---
 deleteLogs="-no"
+FRESH_CLONE=""
 BRANCH=""
+FALLBACK_TIER=""
 while [ $# -gt 0 ]; do
   if [ "$1" = "-d" ]; then
     deleteLogs="-d"
+  elif [ "$1" = "-f" ]; then
+    FRESH_CLONE=1
   elif [ -z "$BRANCH" ]; then
     BRANCH="$1"
+  elif [ -z "$FALLBACK_TIER" ]; then
+    FALLBACK_TIER="$1"
   fi
   shift
 done
@@ -29,6 +42,22 @@ done
 if [ -z "$BRANCH" ]; then
   BRANCH="main"
 fi
+
+# If no fallback tier specified, derive from the branch itself
+if [ -z "$FALLBACK_TIER" ]; then
+  case "${BRANCH:l}" in
+    dev) FALLBACK_TIER="dev" ;;
+    qa)  FALLBACK_TIER="qa" ;;
+    *)   FALLBACK_TIER="main" ;;
+  esac
+fi
+
+# Normalize fallback tier: anything other than dev or qa becomes main
+case "${FALLBACK_TIER:l}" in
+  dev) FALLBACK_TIER="dev" ;;
+  qa)  FALLBACK_TIER="qa" ;;
+  *)   FALLBACK_TIER="main" ;;
+esac
 
 # --- delete past logs (prompt unless -d) ---
 if ls "${SCRIPT_DIR}"/build_clients_*.log >/dev/null 2>&1; then
@@ -56,6 +85,8 @@ echo "===== Build started $(date) =====" > "$LOG"
 
 FAILCOUNT=0
 FAILS=()
+SKIPCOUNT=0
+SKIPS=()
 
 log() {
   echo "$*"
@@ -72,43 +103,122 @@ markfail() {
   FAILS+=("[$1] $2 :: $3")
 }
 
+markskip() {
+  SKIPCOUNT=$((SKIPCOUNT + 1))
+  SKIPS+=("[$1] $2 ($3): $4")
+}
+
 # --- checkout with fallback logic ---
 checkout_branch() {
   local cb_type="$1"
   local cb_repo="$2"
-  local branch_lower="${BRANCH:l}"   # zsh lowercase
+  local branch_lower="${BRANCH:l}"
 
   log "> git checkout $BRANCH..."
   if run git checkout "$BRANCH"; then
+    CHECKED_OUT_BRANCH="$BRANCH"
     return
   fi
 
-  # Branch didn't exist — apply fallback logic
-  if [ "$branch_lower" = "dev" ]; then
+  # Branch didn't exist -- apply fallback based on FALLBACK_TIER
+  if [ "$FALLBACK_TIER" = "dev" ]; then
+    if [ "$branch_lower" != "dev" ]; then
+      log "> Branch \"$BRANCH\" not found, trying \"dev\"..."
+      if run git checkout dev; then
+        CHECKED_OUT_BRANCH="dev"
+        return
+      fi
+    fi
+
     log "> Branch \"dev\" not found, trying \"qa\"..."
     if run git checkout qa; then
+      CHECKED_OUT_BRANCH="qa"
       return
     fi
+
     log "> Branch \"qa\" not found, falling back to \"main\"..."
     if ! run git checkout main; then
-      markfail "$cb_type" "$cb_repo" "git checkout main (fallback from dev)"
+      markfail "$cb_type" "$cb_repo" "git checkout main (fallback from $BRANCH)"
     fi
+    CHECKED_OUT_BRANCH="main"
+    return
+  fi
+
+  if [ "$FALLBACK_TIER" = "qa" ]; then
+    if [ "$branch_lower" != "qa" ]; then
+      log "> Branch \"$BRANCH\" not found, trying \"qa\"..."
+      if run git checkout qa; then
+        CHECKED_OUT_BRANCH="qa"
+        return
+      fi
+    fi
+
+    log "> Branch \"qa\" not found, falling back to \"main\"..."
+    if ! run git checkout main; then
+      markfail "$cb_type" "$cb_repo" "git checkout main (fallback from $BRANCH)"
+    fi
+    CHECKED_OUT_BRANCH="main"
     return
   fi
 
   if [ "$branch_lower" = "qa" ]; then
+    if [ "$branch_lower" != "qa" ]; then
+      log "> Branch \"$BRANCH\" not found, trying \"qa\"..."
+      if run git checkout qa; then
+        CHECKED_OUT_BRANCH="qa"
+        return
+      fi
+    fi
+
     log "> Branch \"qa\" not found, falling back to \"main\"..."
     if ! run git checkout main; then
-      markfail "$cb_type" "$cb_repo" "git checkout main (fallback from qa)"
+      markfail "$cb_type" "$cb_repo" "git checkout main (fallback from $BRANCH)"
     fi
+    CHECKED_OUT_BRANCH="main"
     return
   fi
 
-  # Any other branch — fall back to main
+  # FALLBACK_TIER is main -- fall back directly to main
   log "> Branch \"$BRANCH\" not found, falling back to \"main\"..."
   if ! run git checkout main; then
     markfail "$cb_type" "$cb_repo" "git checkout main (fallback from $BRANCH)"
   fi
+  CHECKED_OUT_BRANCH="main"
+}
+
+# --- pull logic ---
+safe_pull() {
+  local sp_type="$1"
+  local sp_repo="$2"
+
+  if [ -n "$FRESH_CLONE" ]; then
+    log "> Skipping pull -- -f flag set, 'fresh' clone, no pull"
+    markskip "$sp_type" "$sp_repo" "$CHECKED_OUT_BRANCH" "-f flag set, 'fresh' clone, no pull"
+    return
+  fi
+
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    log "> Skipping pull -- uncommitted local changes detected on \"$CHECKED_OUT_BRANCH\", no pull"
+    markskip "$sp_type" "$sp_repo" "$CHECKED_OUT_BRANCH" "uncommitted local changes, no pull"
+    return
+  fi
+
+  if ! git rev-parse --verify "origin/$CHECKED_OUT_BRANCH" >/dev/null 2>&1; then
+    log "> Skipping pull -- origin/$CHECKED_OUT_BRANCH does not exist, no pull"
+    markskip "$sp_type" "$sp_repo" "$CHECKED_OUT_BRANCH" "origin/$CHECKED_OUT_BRANCH does not exist, no pull"
+    return
+  fi
+
+  local local_ahead
+  local_ahead=$(git rev-list "origin/$CHECKED_OUT_BRANCH..HEAD" --count 2>/dev/null)
+  if [ "$local_ahead" -gt 0 ] 2>/dev/null; then
+    log "> Skipping pull -- \"$CHECKED_OUT_BRANCH\" has $local_ahead unpushed commit(s), no pull"
+    markskip "$sp_type" "$sp_repo" "$CHECKED_OUT_BRANCH" "$local_ahead unpushed commit(s), no pull"
+    return
+  fi
+
+  log "> git pull origin $CHECKED_OUT_BRANCH..."
+  if ! run git pull origin "$CHECKED_OUT_BRANCH"; then markfail "$sp_type" "$sp_repo" "git pull origin $CHECKED_OUT_BRANCH"; fi
 }
 
 # --- original counting approach ---
@@ -132,9 +242,7 @@ for ((i=1;i<=count;i++)); do
     else
       cd "$asset"
       checkout_branch "ASSET" "$asset"
-
-      log "> git pull..."
-      if ! run git pull; then markfail "ASSET" "$asset" "git pull"; fi
+      safe_pull "ASSET" "$asset"
 
       log "################################ END Asset $i: $asset ################################"
       log
@@ -157,9 +265,7 @@ for ((i=1;i<=count;i++)); do
     else
       cd "$client"
       checkout_branch "CLIENT" "$client"
-
-      log "> git pull..."
-      if ! run git pull; then markfail "CLIENT" "$client" "git pull"; fi
+      safe_pull "CLIENT" "$client"
 
       log "> npm ci..."
       if ! run npm ci; then markfail "CLIENT" "$client" "npm ci"; fi
@@ -184,7 +290,14 @@ if [ "$FAILCOUNT" -eq 0 ]; then
 else
   echo "Failed steps: $FAILCOUNT"
   for f in "${FAILS[@]}"; do
-    echo "$f"
+    echo "  $f"
+  done
+fi
+if [ "$SKIPCOUNT" -gt 0 ]; then
+  echo
+  echo "Skipped pulls: $SKIPCOUNT"
+  for s in "${SKIPS[@]}"; do
+    echo "  $s"
   done
 fi
 echo

--- a/windows/scripts/build_clients.bat
+++ b/windows/scripts/build_clients.bat
@@ -11,8 +11,8 @@ REM     The second non-flag argument is the fallback tier: dev, qa, or main (def
 REM Examples:
 REM   .\build_clients.bat                        # defaults to "main"
 REM   .\build_clients.bat dev                    # tries dev → qa → main
-REM   .\build_clients.bat my-feature dev         # tries my-feature → dev → qa → main
-REM   .\build_clients.bat my-feature qa -d       # tries my-feature → qa → main, deletes past logs
+REM   .\build_clients.bat my-branch dev         # tries my-branch → dev → qa → main
+REM   .\build_clients.bat my-branch qa -d       # tries my-branch → qa → main, deletes past logs
 REM   .\build_clients.bat -f -d dev              # fresh clones (skips pulling), delete logs, branch=dev → qa → main
 
 set "deleteLogs="
@@ -295,8 +295,8 @@ set "SP_TYPE=%~1"
 set "SP_REPO=%~2"
 
 if defined FRESH_CLONE (
-  call :log ^> Skipping pull -- no pull - fresh clone -f
-  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "no pull - fresh clone -f"
+  call :log ^> Skipping pull -- -f 'fresh' clone, no pull
+  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "-f 'fresh' clone, no pull"
   goto :safe_pull_done
 )
 

--- a/windows/scripts/build_clients.bat
+++ b/windows/scripts/build_clients.bat
@@ -1,5 +1,4 @@
 @echo off
-set "SCRIPT_DIR=%~dp0"
 REM Run from pankosmia\[this-repo's-name]\windows\scripts directory in PowerShell or cmd by:  .\build_clients.bat
 
 REM Usage:
@@ -12,10 +11,11 @@ REM     The second non-flag argument is the fallback tier: dev, qa, or main (def
 REM Examples:
 REM   .\build_clients.bat                        # defaults to "main"
 REM   .\build_clients.bat dev                    # tries dev → qa → main
-REM   .\build_clients.bat my-branch dev         # tries my-branch → dev → qa → main
-REM   .\build_clients.bat my-branch qa -d       # tries my-branch → qa → main, deletes past logs
+REM   .\build_clients.bat my-branch dev          # tries my-branch → dev → qa → main
+REM   .\build_clients.bat my-branch qa -d        # tries my-branch → qa → main, deletes past logs
 REM   .\build_clients.bat -f -d dev              # fresh clones (skips pulling), delete logs, branch=dev → qa → main
 
+set "SCRIPT_DIR=%~dp0"
 set "deleteLogs="
 set "BRANCH="
 set "FALLBACK_TIER="

--- a/windows/scripts/build_clients.bat
+++ b/windows/scripts/build_clients.bat
@@ -1,10 +1,24 @@
 @echo off
-REM Run from pankosmia\[this-repo's-name]\windows\scripts directory in PowerShell with `.\build_clients.bat`, or in cmd with `build_clients.bat`.
+REM Run from pankosmia\[this-repo's-name]\windows\scripts directory in PowerShell or cmd by:  .\build_clients.bat
 
-REM The -d positional argument means to delete past logs without asking
-REM The first non-flag positional argument is the branch name (default: main)
+REM Usage:
+REM   .\build_clients.bat [branch] [fallback_tier] [-d] [-f]
+REM     The -d argument means to delete past logs without asking
+REM     The -f argument means only fresh clones are being built, so pulling is skipped.
+REM     The first non-flag argument is the branch name (default: main)
+REM     The second non-flag argument is the fallback tier: dev, qa, or main (default: same as branch)
+
+REM Examples:
+REM   .\build_clients.bat                        # defaults to "main"
+REM   .\build_clients.bat dev                    # tries dev → qa → main
+REM   .\build_clients.bat my-feature dev         # tries my-feature → dev → qa → main
+REM   .\build_clients.bat my-feature qa -d       # tries my-feature → qa → main, deletes past logs
+REM   .\build_clients.bat -f -d dev              # fresh clones (skips pulling), delete logs, branch=dev → qa → main
+
 set "deleteLogs="
 set "BRANCH="
+set "FALLBACK_TIER="
+set "FRESH_CLONE="
 
 :loop
 if "%~1"=="" goto :continue
@@ -13,9 +27,20 @@ if /I "%~1"=="-d" (
   shift
   goto :loop
 )
+if /I "%~1"=="-f" (
+  set "FRESH_CLONE=1"
+  shift
+  goto :loop
+)
 REM First non-flag argument is the branch
 if not defined BRANCH (
   set "BRANCH=%~1"
+  shift
+  goto :loop
+)
+REM Second non-flag argument is the fallback tier
+if not defined FALLBACK_TIER (
+  set "FALLBACK_TIER=%~1"
   shift
   goto :loop
 )
@@ -27,6 +52,26 @@ goto :loop
 REM Assign default values
 if not defined deleteLogs set "deleteLogs=-no"
 if not defined BRANCH set "BRANCH=main"
+
+REM If no fallback tier specified, derive from the branch itself
+if not defined FALLBACK_TIER (
+  if /I "%BRANCH%"=="dev" (
+    set "FALLBACK_TIER=dev"
+  ) else if /I "%BRANCH%"=="qa" (
+    set "FALLBACK_TIER=qa"
+  ) else (
+    set "FALLBACK_TIER=main"
+  )
+)
+
+REM Normalize fallback tier: anything other than dev or qa becomes main
+if /I "%FALLBACK_TIER%"=="dev" (
+  set "FALLBACK_TIER=dev"
+) else if /I "%FALLBACK_TIER%"=="qa" (
+  set "FALLBACK_TIER=qa"
+) else (
+  set "FALLBACK_TIER=main"
+)
 
 if exist "build_clients_*.log" (
   echo.
@@ -57,6 +102,7 @@ for /f %%I in ('powershell -NoProfile -Command "Get-Date -Format yyyyMMdd_HHmmss
 set "LOG=%~dp0build_clients_%TS%.log"
 > "%LOG%" echo ===== Build started %DATE% %TIME% =====
 set /a FAILCOUNT=0
+set /a SKIPCOUNT=0
 
 REM Create a tiny PowerShell helper script once (used for tee-ing output)
 set "PSRUNNER=%TEMP%\bat_tee_run.ps1"
@@ -98,10 +144,7 @@ for /l %%a in (1,1,%count%) do (
     ) else (
       cd !ASSET%%a!
       call :checkout_branch "ASSET" "!ASSET%%a!"
-
-      call :log ^> git pull...
-      call :run git pull
-      if errorlevel 1 call :markfail "ASSET" "!ASSET%%a!" "git pull"
+      call :safe_pull "ASSET" "!ASSET%%a!"
 
       call :log ################################ END Asset %%a: !ASSET%%a! ################################
       call :log
@@ -124,10 +167,7 @@ for /l %%a in (1,1,%count%) do (
     ) else (
       cd !CLIENT%%a!
       call :checkout_branch "CLIENT" "!CLIENT%%a!"
-
-      call :log ^> git pull...
-      call :run git pull
-      if errorlevel 1 call :markfail "CLIENT" "!CLIENT%%a!" "git pull"
+      call :safe_pull "CLIENT" "!CLIENT%%a!"
 
       call :log ^> npm ci...
       call :run npm ci
@@ -153,7 +193,12 @@ if %FAILCOUNT% EQU 0 (
   echo All builds succeeded.
 ) else (
   echo Failed steps: %FAILCOUNT%
-  for /l %%i in (1,1,%FAILCOUNT%) do echo !FAIL%%i!
+  for /l %%i in (1,1,%FAILCOUNT%) do echo   !FAIL%%i!
+)
+if %SKIPCOUNT% GTR 0 (
+  echo.
+  echo Skipped pulls: %SKIPCOUNT%
+  for /l %%i in (1,1,%SKIPCOUNT%) do echo   !SKIP%%i!
 )
 echo.
 if /i "%GITHUB_ACTIONS%"=="true" (
@@ -172,39 +217,123 @@ exit /b %EXITCODE%
 
 :checkout_branch
 REM %~1 = type (ASSET or CLIENT), %~2 = repo name
-REM Uses %BRANCH% to determine which branch to check out, with fallback logic.
+REM Uses %BRANCH% and %FALLBACK_TIER% to determine checkout with fallback.
+REM Sets CHECKED_OUT_BRANCH to the branch that was actually checked out.
 set "CB_TYPE=%~1"
 set "CB_REPO=%~2"
 
 call :log ^> git checkout %BRANCH%...
 call :run git checkout %BRANCH%
-if not errorlevel 1 goto :checkout_done
+if not errorlevel 1 (
+  set "CHECKED_OUT_BRANCH=%BRANCH%"
+  goto :checkout_done
+)
 
-REM Branch didn't exist — apply fallback logic
-if /I "%BRANCH%"=="dev" (
+REM Branch didn't exist -- apply fallback based on FALLBACK_TIER
+if /I "%FALLBACK_TIER%"=="dev" (
+  REM Fallback chain: dev -> qa -> main
+  if /I "%BRANCH%" NEQ "dev" (
+    call :log ^> Branch "%BRANCH%" not found, trying "dev"...
+    call :run git checkout dev
+    if not errorlevel 1 (
+      set "CHECKED_OUT_BRANCH=dev"
+      goto :checkout_done
+    )
+  )
+
   call :log ^> Branch "dev" not found, trying "qa"...
   call :run git checkout qa
-  if not errorlevel 1 goto :checkout_done
+  if not errorlevel 1 (
+    set "CHECKED_OUT_BRANCH=qa"
+    goto :checkout_done
+  )
 
   call :log ^> Branch "qa" not found, falling back to "main"...
   call :run git checkout main
-  if errorlevel 1 call :markfail "%CB_TYPE%" "%CB_REPO%" "git checkout main (fallback from dev)"
+  if errorlevel 1 (
+    call :markfail "%CB_TYPE%" "%CB_REPO%" "git checkout main (fallback from %BRANCH%)"
+  )
+  set "CHECKED_OUT_BRANCH=main"
   goto :checkout_done
 )
 
-if /I "%BRANCH%"=="qa" (
+if /I "%FALLBACK_TIER%"=="qa" (
+  REM Fallback chain: qa -> main
+  if /I "%BRANCH%" NEQ "qa" (
+    call :log ^> Branch "%BRANCH%" not found, trying "qa"...
+    call :run git checkout qa
+    if not errorlevel 1 (
+      set "CHECKED_OUT_BRANCH=qa"
+      goto :checkout_done
+    )
+  )
+
   call :log ^> Branch "qa" not found, falling back to "main"...
   call :run git checkout main
-  if errorlevel 1 call :markfail "%CB_TYPE%" "%CB_REPO%" "git checkout main (fallback from qa)"
+  if errorlevel 1 (
+    call :markfail "%CB_TYPE%" "%CB_REPO%" "git checkout main (fallback from %BRANCH%)"
+  )
+  set "CHECKED_OUT_BRANCH=main"
   goto :checkout_done
 )
 
-REM Any other branch — fall back to main
+REM FALLBACK_TIER is main -- fall back directly to main
 call :log ^> Branch "%BRANCH%" not found, falling back to "main"...
 call :run git checkout main
-if errorlevel 1 call :markfail "%CB_TYPE%" "%CB_REPO%" "git checkout main (fallback from %BRANCH%)"
+if errorlevel 1 (
+  call :markfail "%CB_TYPE%" "%CB_REPO%" "git checkout main (fallback from %BRANCH%)"
+)
+set "CHECKED_OUT_BRANCH=main"
 
 :checkout_done
+exit /b 0
+
+
+:safe_pull
+REM %~1 = type (ASSET or CLIENT), %~2 = repo name
+set "SP_TYPE=%~1"
+set "SP_REPO=%~2"
+
+if defined FRESH_CLONE (
+  call :log ^> Skipping pull -- no pull - fresh clone -f
+  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "no pull - fresh clone -f"
+  goto :safe_pull_done
+)
+
+git diff --quiet >nul 2>&1
+set "DIRTY1=!errorlevel!"
+git diff --cached --quiet >nul 2>&1
+set "DIRTY2=!errorlevel!"
+if !DIRTY1! NEQ 0 (
+  call :log ^> Skipping pull -- uncommitted local changes detected on "!CHECKED_OUT_BRANCH!"
+  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "uncommitted local changes"
+  goto :safe_pull_done
+)
+if !DIRTY2! NEQ 0 (
+  call :log ^> Skipping pull -- uncommitted local changes detected on "!CHECKED_OUT_BRANCH!"
+  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "uncommitted local changes"
+  goto :safe_pull_done
+)
+
+git rev-parse --verify "origin/!CHECKED_OUT_BRANCH!" >nul 2>&1
+if errorlevel 1 (
+  call :log ^> Skipping pull -- origin/!CHECKED_OUT_BRANCH! does not exist
+  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "origin/!CHECKED_OUT_BRANCH! does not exist"
+  goto :safe_pull_done
+)
+
+for /f %%n in ('git rev-list "origin/!CHECKED_OUT_BRANCH!..HEAD" --count 2^>nul') do set "LOCAL_AHEAD=%%n"
+if !LOCAL_AHEAD! GTR 0 (
+  call :log ^> Skipping pull -- "!CHECKED_OUT_BRANCH!" has !LOCAL_AHEAD! unpushed commit(s^)
+  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "!LOCAL_AHEAD! unpushed commit(s)"
+  goto :safe_pull_done
+)
+
+call :log ^> git pull origin !CHECKED_OUT_BRANCH!...
+call :run git pull origin !CHECKED_OUT_BRANCH!
+if errorlevel 1 call :markfail "%SP_TYPE%" "%SP_REPO%" "git pull origin !CHECKED_OUT_BRANCH!"
+
+:safe_pull_done
 exit /b 0
 
 
@@ -231,4 +360,10 @@ exit /b %errorlevel%
 :markfail
 set /a FAILCOUNT+=1
 set "FAIL!FAILCOUNT!=[%~1] %~2 :: %~3"
+exit /b 0
+
+
+:markskip
+set /a SKIPCOUNT+=1
+set "SKIP!SKIPCOUNT!=[%~1] %~2 (%~3): %~4"
 exit /b 0

--- a/windows/scripts/build_clients.bat
+++ b/windows/scripts/build_clients.bat
@@ -1,4 +1,5 @@
 @echo off
+set "SCRIPT_DIR=%~dp0"
 REM Run from pankosmia\[this-repo's-name]\windows\scripts directory in PowerShell or cmd by:  .\build_clients.bat
 
 REM Usage:
@@ -99,12 +100,12 @@ setlocal ENABLEDELAYEDEXPANSION
 
 REM ---- logging + failure tracking ----
 for /f %%I in ('powershell -NoProfile -Command "Get-Date -Format yyyyMMdd_HHmmss"') do set "TS=%%I"
-set "LOG=%~dp0build_clients_%TS%.log"
+set "LOG=%SCRIPT_DIR%build_clients_%TS%.log"
 > "%LOG%" echo ===== Build started %DATE% %TIME% =====
 set /a FAILCOUNT=0
 set /a SKIPCOUNT=0
 
-REM Create a tiny PowerShell helper script once (used for tee-ing output)
+REM Create a PowerShell helper script (used for tee-ing output)
 set "PSRUNNER=%TEMP%\bat_tee_run.ps1"
 del "%PSRUNNER%" 2>nul
 >  "%PSRUNNER%" echo $LogPath = $args[0]
@@ -169,11 +170,11 @@ for /l %%a in (1,1,%count%) do (
       call :checkout_branch "CLIENT" "!CLIENT%%a!"
       call :safe_pull "CLIENT" "!CLIENT%%a!"
 
-      call :log ^> npm ci...
+      call :log -- npm ci...
       call :run npm ci
       if errorlevel 1 call :markfail "CLIENT" "!CLIENT%%a!" "npm ci"
 
-      call :log ^> npm run build...
+      call :log -- npm run build...
       call :run npm run build
       if errorlevel 1 call :markfail "CLIENT" "!CLIENT%%a!" "npm run build"
 
@@ -222,8 +223,8 @@ REM Sets CHECKED_OUT_BRANCH to the branch that was actually checked out.
 set "CB_TYPE=%~1"
 set "CB_REPO=%~2"
 
-call :log ^> git checkout %BRANCH%...
-call :run git checkout %BRANCH%
+call :log -- git checkout %BRANCH%...
+call :run git checkout "%BRANCH%"
 if not errorlevel 1 (
   set "CHECKED_OUT_BRANCH=%BRANCH%"
   goto :checkout_done
@@ -233,7 +234,7 @@ REM Branch didn't exist -- apply fallback based on FALLBACK_TIER
 if /I "%FALLBACK_TIER%"=="dev" (
   REM Fallback chain: dev -> qa -> main
   if /I "%BRANCH%" NEQ "dev" (
-    call :log ^> Branch "%BRANCH%" not found, trying "dev"...
+    call :log -- Branch "%BRANCH%" not found, trying "dev"...
     call :run git checkout dev
     if not errorlevel 1 (
       set "CHECKED_OUT_BRANCH=dev"
@@ -241,14 +242,14 @@ if /I "%FALLBACK_TIER%"=="dev" (
     )
   )
 
-  call :log ^> Branch "dev" not found, trying "qa"...
+  call :log -- Branch "dev" not found, trying "qa"...
   call :run git checkout qa
   if not errorlevel 1 (
     set "CHECKED_OUT_BRANCH=qa"
     goto :checkout_done
   )
 
-  call :log ^> Branch "qa" not found, falling back to "main"...
+  call :log -- Branch "qa" not found, falling back to "main"...
   call :run git checkout main
   if errorlevel 1 (
     call :markfail "%CB_TYPE%" "%CB_REPO%" "git checkout main (fallback from %BRANCH%)"
@@ -260,7 +261,7 @@ if /I "%FALLBACK_TIER%"=="dev" (
 if /I "%FALLBACK_TIER%"=="qa" (
   REM Fallback chain: qa -> main
   if /I "%BRANCH%" NEQ "qa" (
-    call :log ^> Branch "%BRANCH%" not found, trying "qa"...
+    call :log -- Branch "%BRANCH%" not found, trying "qa"...
     call :run git checkout qa
     if not errorlevel 1 (
       set "CHECKED_OUT_BRANCH=qa"
@@ -268,7 +269,7 @@ if /I "%FALLBACK_TIER%"=="qa" (
     )
   )
 
-  call :log ^> Branch "qa" not found, falling back to "main"...
+  call :log -- Branch "qa" not found, falling back to "main"...
   call :run git checkout main
   if errorlevel 1 (
     call :markfail "%CB_TYPE%" "%CB_REPO%" "git checkout main (fallback from %BRANCH%)"
@@ -278,7 +279,7 @@ if /I "%FALLBACK_TIER%"=="qa" (
 )
 
 REM FALLBACK_TIER is main -- fall back directly to main
-call :log ^> Branch "%BRANCH%" not found, falling back to "main"...
+call :log -- Branch "%BRANCH%" not found, falling back to "main"...
 call :run git checkout main
 if errorlevel 1 (
   call :markfail "%CB_TYPE%" "%CB_REPO%" "git checkout main (fallback from %BRANCH%)"
@@ -295,8 +296,8 @@ set "SP_TYPE=%~1"
 set "SP_REPO=%~2"
 
 if defined FRESH_CLONE (
-  call :log ^> Skipping pull -- -f 'fresh' clone, no pull
-  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "-f 'fresh' clone, no pull"
+  call :log -- Skipping pull -- -f flag set, 'fresh' clone, no pull
+  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "-f flag set, 'fresh' clone, no pull"
   goto :safe_pull_done
 )
 
@@ -305,32 +306,32 @@ set "DIRTY1=!errorlevel!"
 git diff --cached --quiet >nul 2>&1
 set "DIRTY2=!errorlevel!"
 if !DIRTY1! NEQ 0 (
-  call :log ^> Skipping pull -- uncommitted local changes detected on "!CHECKED_OUT_BRANCH!"
-  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "uncommitted local changes"
+  call :log -- Skipping pull -- uncommitted local changes detected on "!CHECKED_OUT_BRANCH!", no pull
+  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "uncommitted local changes, no pull"
   goto :safe_pull_done
 )
 if !DIRTY2! NEQ 0 (
-  call :log ^> Skipping pull -- uncommitted local changes detected on "!CHECKED_OUT_BRANCH!"
-  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "uncommitted local changes"
+  call :log -- Skipping pull -- uncommitted local changes detected on "!CHECKED_OUT_BRANCH!", no pull
+  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "uncommitted local changes, no pull"
   goto :safe_pull_done
 )
 
 git rev-parse --verify "origin/!CHECKED_OUT_BRANCH!" >nul 2>&1
 if errorlevel 1 (
-  call :log ^> Skipping pull -- origin/!CHECKED_OUT_BRANCH! does not exist
-  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "origin/!CHECKED_OUT_BRANCH! does not exist"
+  call :log -- Skipping pull -- origin/!CHECKED_OUT_BRANCH! does not exist, no pull
+  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "origin/!CHECKED_OUT_BRANCH! does not exist, no pull"
   goto :safe_pull_done
 )
 
 for /f %%n in ('git rev-list "origin/!CHECKED_OUT_BRANCH!..HEAD" --count 2^>nul') do set "LOCAL_AHEAD=%%n"
 if !LOCAL_AHEAD! GTR 0 (
-  call :log ^> Skipping pull -- "!CHECKED_OUT_BRANCH!" has !LOCAL_AHEAD! unpushed commit(s^)
-  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "!LOCAL_AHEAD! unpushed commit(s)"
+  call :log -- Skipping pull -- "!CHECKED_OUT_BRANCH!" has !LOCAL_AHEAD! unpushed commits, no pull
+  call :markskip "%SP_TYPE%" "%SP_REPO%" "!CHECKED_OUT_BRANCH!" "!LOCAL_AHEAD! unpushed commits, no pull"
   goto :safe_pull_done
 )
 
-call :log ^> git pull origin !CHECKED_OUT_BRANCH!...
-call :run git pull origin !CHECKED_OUT_BRANCH!
+call :log -- git pull origin !CHECKED_OUT_BRANCH!...
+call :run git pull origin "!CHECKED_OUT_BRANCH!"
 if errorlevel 1 call :markfail "%SP_TYPE%" "%SP_REPO%" "git pull origin !CHECKED_OUT_BRANCH!"
 
 :safe_pull_done
@@ -344,7 +345,7 @@ if "%~1"=="" (
   echo.
   powershell -NoProfile -Command "[System.IO.File]::AppendAllText($env:LOG, [Environment]::NewLine, (New-Object System.Text.UTF8Encoding($false)))" >nul
 ) else (
-  echo %LINE%
+  echo !LINE!
   powershell -NoProfile -Command "$s=$env:LINE; [System.IO.File]::AppendAllText($env:LOG, $s + [Environment]::NewLine, (New-Object System.Text.UTF8Encoding($false)))" >nul
 )
 exit /b 0
@@ -352,7 +353,6 @@ exit /b 0
 
 :run
 REM Runs a command, shows output live, and appends the same output to %LOG%.
-REM Preserves the original program exit code.
 powershell -NoProfile -ExecutionPolicy Bypass -File "%PSRUNNER%" "%LOG%" %*
 exit /b %errorlevel%
 


### PR DESCRIPTION
- When pulling, now it always does `git pull origin <branch>` to handle dev cases where no remote branch is established.  (It used to just do `git pull` which was safe on main, but that old approach doesn't always work locally on branches, which we switched to when we added dev/qa options.)
- Fixes a script issue in windows when <branch> includes a forward slash (/).
- Skips the unecessary step of "pull" on github actions, because all repos are fresh clones (`-f`).
- Recognizes existence of uncommitted local changes and skips pulling.
- Recognizes when origin/<branch> does not exist and skips pulling.
- Recognizes unpushed commits and skips pulling.
- Summarizes all repos/branches were pull was skipped with the reason.
- Accommodates dev building scenarios for catching up all repos, as follows:
  - `./build_clients.<ext> my-branch dev # tries my-branch → dev → qa → main on all repos`
  - `./build_clients.<ext> my-branch qa  # tries my-branch → qa → main on all repos`
  - `./build_clients.<ext> my-branch     # tries my-branch → main on all repos`
  - `./build_clients.<ext> dev           # tries dev → qa → main on all repos`
  - `./build_clients.<ext> qa            # tries qa → main on all repos`

| new | windows | linux | macos |
|---|---|---|---|
| `/` in branch name | tested | tested | tested |
| `-f` 'fresh' clone local, no pull | tested | tested | tested |
| `-f` 'fresh' clone GHA, no pull | tested | tested | tested |
| uncommitted local changes, no pull | tested | tested | tested |
| origin/[branch] does not exist, no pull | tested | tested | tested |
| unpushed commits, no pull | tested | tested | tested |
| `git pull origin <branch>` local | tested | tested |  tested |