### PR TITLE
Debug Mode => Log Level swap

### DIFF
--- a/.github/workflows/buildMaster.yml
+++ b/.github/workflows/buildMaster.yml
@@ -37,7 +37,7 @@ on:
           - critical
           - normal
           - debug
-          - off
+          - 'off'
         default: critical
 
 # set run name from input so the run appears with that name (no API call needed)

--- a/.github/workflows/buildMaster.yml
+++ b/.github/workflows/buildMaster.yml
@@ -29,21 +29,23 @@ on:
           - macos
         default: all
 
-      server_type:
-        description: 'Server type'
+      log_level:
+        description: 'Log level'
         required: true
         type: choice
         options:
-          - release
+          - critical
+          - normal
           - debug
-        default: release
+          - off
+        default: critical
 
 # set run name from input so the run appears with that name (no API call needed)
 run-name: >-
   Master Build
   - ${{ inputs.branches }}
   - ${{ inputs.os == 'all' && 'all OSes' || inputs.os }}
-  - ${{ inputs.server_type }} server
+  - log=${{ inputs.log_level }}
 
 jobs:
   build:
@@ -52,7 +54,7 @@ jobs:
       - run: |
           echo "Branches is ${{ inputs.branches }}"
           echo "OS is ${{ inputs.os }}"
-          echo "Server type is ${{ inputs.server_type }}"
+          echo "Log level is ${{ inputs.log_level }}"
 
   build-macos-intel:
     name: Build on macOS Intel64 (x64)
@@ -61,7 +63,7 @@ jobs:
     with:
       runner: macos-15-intel
       delay_seconds: 1
-      server_type: ${{ inputs.server_type }}
+      log_level: ${{ inputs.log_level }}
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
 
   build-macos-arm:
@@ -71,7 +73,7 @@ jobs:
     with:
       runner: macos-14
       delay_seconds: 600
-      server_type: ${{ inputs.server_type }}
+      log_level: ${{ inputs.log_level }}
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
 
   build-windows:
@@ -80,7 +82,7 @@ jobs:
     uses: ./.github/workflows/windows-build-steps.yml
     with:
       runner: windows-2025
-      server_type: ${{ inputs.server_type }}
+      log_level: ${{ inputs.log_level }}
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
 
   build-linux:
@@ -89,7 +91,7 @@ jobs:
     uses: ./.github/workflows/linux-build-steps.yml
     with:
       runner: ubuntu-22.04
-      server_type: ${{ inputs.server_type }}
+      log_level: ${{ inputs.log_level }}
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
 
   finalize:

--- a/.github/workflows/linux-build-steps.yml
+++ b/.github/workflows/linux-build-steps.yml
@@ -10,7 +10,7 @@ on:
       branches:
         required: true
         type: string
-      server_type:
+      log_level:
         required: true
         type: string
     outputs:
@@ -32,16 +32,16 @@ jobs:
     env:
       CI: false
       BRANCHES: ${{ inputs.branches }}
-      SERVER_TYPE: ${{ inputs.server_type }}
+      LOG_LEVEL: ${{ inputs.log_level }}
 
     steps:
       # Show branches
       - name: Show BRANCHES
         run: echo "BRANCHES = $BRANCHES"
 
-      # Show server type
-      - name: Show SERVER TYPE
-        run: echo "SERVER_TYPE = $SERVER_TYPE"
+      # Show log level
+      - name: Show LOG LEVEL
+        run: echo "LOG_LEVEL = $LOG_LEVEL"
 
       # Turn off re-runs
       - name: No re-runs please
@@ -96,15 +96,9 @@ jobs:
         working-directory: ./linux/scripts
         run: ./build_clients.bsh -f "$BRANCHES"
 
-      - name: Build ${{ inputs.branches }} DEBUG server and assemble build environment without asking if the server is off
-        working-directory: ./linux/scripts
-        if: env.SERVER_TYPE == 'debug'
-        run: ./build_server.bsh -s -d "$BRANCHES"
-
       - name: Build ${{ inputs.branches }} RELEASE server and assemble build environment without asking if the server is off
         working-directory: ./linux/scripts
-        if: env.SERVER_TYPE == 'release'
-        run: ./build_server.bsh -s "$BRANCHES"
+        run: ./build_server.bsh -s "$BRANCHES" "$LOG_LEVEL"
 
       - name: Bundle tgz without asking if the server is off and indicate GHA
         working-directory: ./linux/scripts

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -11,7 +11,7 @@ on:
       branches:
         required: true
         type: string
-      server_type:
+      log_level:
         required: true
         type: string
       delay_seconds:
@@ -47,16 +47,16 @@ jobs:
     env:
       CI: false
       BRANCHES: ${{ inputs.branches }}
-      SERVER_TYPE: ${{ inputs.server_type }}
+      LOG_LEVEL: ${{ inputs.log_level }}
 
     steps:
       # Show branches
       - name: Show BRANCHES
         run: echo "BRANCHES = $BRANCHES"
 
-      # Show server type
-      - name: Show SERVER TYPE
-        run: echo "SERVER_TYPE = $SERVER_TYPE"
+      # Show log level
+      - name: Show LOG LEVEL
+        run: echo "LOG_LEVEL = $LOG_LEVEL"
 
       # Turn off re-runs
       - name: No re-runs please
@@ -133,15 +133,9 @@ jobs:
         working-directory: ./macos/scripts
         run: ./build_clients.zsh -f "$BRANCHES"
 
-      - name: Build ${{ inputs.branches }} DEBUG server and assemble build environment without asking if the server is off
-        working-directory: ./macos/scripts
-        if: env.SERVER_TYPE == 'debug'
-        run: ./build_server.zsh -s -d "$BRANCHES"
-
       - name: Build ${{ inputs.branches }} RELEASE server and assemble build environment without asking if the server is off
         working-directory: ./macos/scripts
-        if: env.SERVER_TYPE == 'release'
-        run: ./build_server.zsh -s "$BRANCHES"
+        run: ./build_server.zsh -s "$BRANCHES" "$LOG_LEVEL"
 
       - name: Bundle zip without asking if the server is off and indicate GHA
         working-directory: ./macos/scripts

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -10,7 +10,7 @@ on:
       branches:
         required: true
         type: string
-      server_type:
+      log_level:
         required: true
         type: string
     outputs:
@@ -36,16 +36,16 @@ jobs:
     env:
       CI: false
       BRANCHES: ${{ inputs.branches }}
-      SERVER_TYPE: ${{ inputs.server_type }}
+      LOG_LEVEL: ${{ inputs.log_level }}
 
     steps:
       # Show branches
       - name: Show BRANCHES
         run: echo "BRANCHES = $env:BRANCHES"
 
-      # Show server type
-      - name: Show SERVER TYPE
-        run: echo "SERVER_TYPE = $env:SERVER_TYPE"
+      # Show log level
+      - name: Show LOG LEVEL
+        run: echo "LOG_LEVEL = $env:LOG_LEVEL"
 
       # Turn off re-runs
       - name: No re-runs please
@@ -122,17 +122,10 @@ jobs:
         working-directory: .\windows\scripts
         run: .\build_clients.bat -f "$env:BRANCHES"
 
-      # Build DEBUG server and assemble build environment without asking if the server is off
-      - name: Run ${{ inputs.branches }} DEBUG server and assemble build environment without asking if the server is off
-        working-directory: .\windows\scripts
-        if: env.SERVER_TYPE == 'debug'
-        run: .\build_server.bat -s -d "$env:BRANCHES"
-
       # Build RELEASE server and assemble build environment without asking if the server is off
       - name: Run ${{ inputs.branches }} RELEASE server and assemble build environment without asking if the server is off
         working-directory: .\windows\scripts
-        if: env.SERVER_TYPE == 'release'
-        run: .\build_server.bat -s "$env:BRANCHES"
+        run: .\build_server.bat -s "$env:BRANCHES" "$env:LOG_LEVEL"
 
       # Bundle zip without asking if the server is off and indicate GHA
       - name: Run bundle_zip.ps1 -ServerOff "Y" -IsGHA "Y"

--- a/linux/scripts/build_server.bsh
+++ b/linux/scripts/build_server.bsh
@@ -5,23 +5,40 @@ set -u
 
 echo
 
-# Do not ask if the server is off if the -s positional argument is provided
-# Debug server if the -d positional argument is provided
-# Specify environment as first non-flag positional argument: dev, qa, or main (default: main)
+# Do not ask if the server is off if the -s argument is provided
+# Specify environment as an optional non-flag argument: dev, qa, or main (default: main)
+# Specify log level as an optional non-flag argument: critical, normal, debug, or off (default: normal)
 envArg=""
+logArg=""
 while [[ "$#" -gt 0 ]]
   do case $1 in
       -s) askIfOff="$1" # -s = "no"
       ;;
-      -d) debugServer="$1" # -d = "yes"
-      ;;
-      *) if [ -z "$envArg" ] && [[ "$1" != -* ]]; then
-           envArg="$1"
+      *) if [[ "$1" != -* ]]; then
+           if [ -z "$logArg" ] && { [ "$1" = "critical" ] || [ "$1" = "normal" ] || [ "$1" = "debug" ] || [ "$1" = "off" ]; }; then
+             logArg="$1"
+           elif [ -z "$envArg" ]; then
+             envArg="$1"
+           fi
          fi
       ;;
   esac
   shift
 done
+
+# Normalize: anything other than critical, debug, or off is treated as normal
+if [ -z "$logArg" ]; then
+  logArg="normal"
+fi
+if [ "$logArg" != "critical" ] && [ "$logArg" != "debug" ] && [ "$logArg" != "off" ]; then
+  logArg="normal"
+fi
+
+# Rewrite the log level in Rocket.toml (read at run time, so the change is left in place)
+rocketFile="../../Rocket.toml"
+
+echo "  Using log level \"$logArg\""
+sed -i "s|^log_level = \"[^\"]*\"|log_level = \"$logArg\"|" "$rocketFile"
 
 # Normalize: anything other than dev or qa is treated as main
 if [ -z "$envArg" ]; then
@@ -35,10 +52,10 @@ fi
 # For main, Cargo.toml already has the correct version — no replacement needed
 cargoFile="../../local_server/Cargo.toml"
 cargoBackup="../../local_server/Cargo.toml.bak"
-didRewrite=0
+didRewriteCargo=0
 
 restore_cargo() {
-  if [ "$didRewrite" -eq 1 ] && [ -f "$cargoBackup" ]; then
+  if [ "$didRewriteCargo" -eq 1 ] && [ -f "$cargoBackup" ]; then
     cp "$cargoBackup" "$cargoFile"
     rm "$cargoBackup"
   fi
@@ -54,35 +71,21 @@ if [ "$envArg" != "main" ]; then
   echo "  Using pankosmia_web version $targetVersion for environment \"$envArg\""
   cp "$cargoFile" "$cargoBackup"
   sed -i "s|pankosmia_web = \"=[^\"]*\"|pankosmia_web = \"=$targetVersion\"|" "$cargoFile"
-  didRewrite=1
+  didRewriteCargo=1
 else
   echo "  Using pankosmia_web version from Cargo.toml (main)"
 fi
 
 # Assign default value if -s is not present
-if [ -z ${askIfOff+x} ]; then # serverOff is unset
+if [ -z ${askIfOff+x} ]; then # askIfOff is unset
   askIfOff=-yes
 fi
 
-# Assign default value if -d is not present
-if [ -z ${debugServer+x} ]; then # debugServer is unset
-  debugServer=-no
-  buildCommand="cargo build --release"
-  search=local_server/target/debug
-  replace=local_server/target/release
-  serverType=release
-elif [[ $debugServer =~ ^(-d) ]]; then
-  buildCommand="cargo build"
-  search=local_server/target/release
-  replace=local_server/target/debug
-  serverType=debug
-fi
-
-# Do not ask if the server is off if the -s $1 or $2 positional argument is provided
+# Do not ask if the server is off if the -s argument is provided
 if ! [[ $askIfOff =~ ^(-s) ]]; then
   while true; do
     read -p "Is the server off? [Y/n]: " yn
-    case $yn in 
+    case $yn in
       "y" | "Y" | "" ) echo
         echo "Continuing...";
         break
@@ -107,18 +110,14 @@ if [ ! -f ../../buildSpec.json ] || [ ! -f ../../globalBuildResources/i18nPatch.
   echo "  +-----------------------------------------------------------------------------+"
   echo "  | Config files were rebuilt by \`./app_setup.bsh\` as one or more were missing. |"
   echo "  +-----------------------------------------------------------------------------+"
-  echo 
+  echo
 fi
 
-# Ensure buildSpec.json has the location for the indicated server build type
-configFile=../../buildSpec.json
-tmpFile=../../buildSpec.bak
-cp $configFile $tmpFile
-sed -i "s|$search|$replace|g" "$configFile"
-
-echo "Building local $serverType server at /$replace ..."
+# Build the rust server (always release)
+echo "Building local Release server at /local_server/target/release ..."
 cd ../../local_server
-$buildCommand
+echo "cargo build --release"
+cargo build --release
 cd ../linux/scripts
 
 # Cargo.toml is restored by the EXIT trap

--- a/linux/scripts/clean.bsh
+++ b/linux/scripts/clean.bsh
@@ -34,7 +34,7 @@ if [ -d ../build ]; then
   rm -rf ../build
 fi
 
-if [ -f ../../local_server/target/release/local_server ] || [ -f ../../local_server/target/debug/local_server ]; then
+if [ -f ../../local_server/target/release/local_server ]; then
     echo "Cleaning local server"
     cd ../../local_server
     cargo clean

--- a/linux/scripts/run.bsh
+++ b/linux/scripts/run.bsh
@@ -1,68 +1,43 @@
 #!/usr/bin/env bash
 
 # Run from pankosmia/[this-repo's-name]/linux/scripts directory by:  ./run.bsh
-# with the optional arguments of: `./run.bsh -s` to pre-specify that the server is off.
-# or the optional arguments of: `./run.bsh -d` to run server in debug mode.
-
+# with the optional argument of: `./run.bsh -s` to pre-specify that the server is off.
 
 set -e
 set -u
 
 echo
 
-# Do not ask if the server is off if the -s positional argument is provided in either #1 or #2
-# Debug server if the -d positional argument is provided in either #1 or #2
+# Do not ask if the server is off if the -s argument is provided
 while [[ "$#" -gt 0 ]]
   do case $1 in
       -s) askIfOff="$1" # -s = "no"
       ;;
-      -d) debugServer="$1" # -d = "yes"
   esac
   shift
 done
 
 # Assign default value if -s is not present
-if [ -z ${askIfOff+x} ]; then # serverOff is unset
+if [ -z ${askIfOff+x} ]; then # askIfOff is unset
   askIfOff=-yes
 fi
 
-missingServer() {
+if [ ! -f ../../local_server/target/release/local_server ]; then
   echo
   echo "      Exiting..."
   echo
-  echo "      The $1 server does not exist. Run \`$2\`, then re-run this script."
+  echo "      The local server does not exist. Run \`./build_server.bsh\`, then re-run this script."
   echo
   exit
-}
-
-# Assign default value if -s is not present
-if [ -z ${debugServer+x} ]; then # debugServer is unset
-  debugServer=-no
-  search=local_server/target/debug
-  replace=local_server/target/release
-  serverType=release
-  script=".\build_server.bat"
-  if [ ! -f ../../local_server/target/release/local_server ]; then
-    missingServer "$serverType" "$script"
-  fi
-elif [[ $debugServer =~ ^(-d) ]]; then
-  search=local_server/target/release
-  replace=local_server/target/debug
-  serverType=debug
-  script=".\build_server.bat -d"
-  if [ ! -f ../../local_server/target/debug/local_server ]; then
-    missingServer "$serverType" "$script"
-  fi
 fi
 
-
-# Do not ask if the server is off if the -s $1 or $2 positional argument is provided
+# Do not ask if the server is off if the -s argument is provided
 if ! [[ $askIfOff =~ ^(-s) ]]; then
   while true; do
     read -p "Is the server off? [Y/n]: " yn
-    case $yn in 
+    case $yn in
       "y" | "Y" | "" ) echo
-        echo "Cleaning..."
+        echo "Continuing..."
         echo
         break
         ;;
@@ -90,12 +65,6 @@ if [ ! -f ../../buildSpec.json ] || [ ! -f ../../globalBuildResources/i18nPatch.
   echo
 fi
 
-# Ensure buildSpec.json has the location for the indicated server build type
-configFile=../../buildSpec.json
-tmpFile=../../buildSpec.bak
-cp $configFile $tmpFile
-sed -i "s|$search|$replace|g" "$configFile"
-
 # set available port environment variable (exported as $ROCKET_PORT )
 source ../buildResources/find_free_port.sh
 echo "Serving on port $ROCKET_PORT..."
@@ -115,7 +84,7 @@ fi
 cd ../build
 
 echo
-echo "Running with local server in $serverType mode... When ready to stop this server, press Ctrl-C."
+echo "Running with local server in release mode... When ready to stop this server, press Ctrl-C."
 echo "       If Ctrl-Z (suspend) is used by accident, then run \`killall -9 \"server.bin\"\` or Force Quit from the Activity Monitor,"
 echo "       or to resume run \`fg\` for the last suspended process, otherwise \`fg \"./run.bsh\"\`."
 echo
@@ -125,4 +94,3 @@ export APP_RESOURCES_DIR="$SCRIPT_DIR/lib/"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 $SCRIPT_DIR/bin/server.bin
-

--- a/macos/scripts/build_server.zsh
+++ b/macos/scripts/build_server.zsh
@@ -5,23 +5,40 @@ set -u
 
 echo
 
-# Do not ask if the server is off if the -s positional argument is provided
-# Debug server if the -d positional argument is provided
-# Specify environment as first non-flag positional argument: dev, qa, or main (default: main)
+# Do not ask if the server is off if the -s argument is provided
+# Specify environment as an optional non-flag argument: dev, qa, or main (default: main)
+# Specify log level as an optional non-flag argument: critical, normal, debug, or off (default: normal)
 envArg=""
+logArg=""
 while [[ "$#" -gt 0 ]]
   do case $1 in
       -s) askIfOff="$1" # -s means "no"
       ;;
-      -d) debugServer="$1" # -d = "yes"
-      ;;
-      *) if [ -z "$envArg" ] && [[ "$1" != -* ]]; then
-           envArg="$1"
+      *) if [[ "$1" != -* ]]; then
+           if [ -z "$logArg" ] && { [ "$1" = "critical" ] || [ "$1" = "normal" ] || [ "$1" = "debug" ] || [ "$1" = "off" ]; }; then
+             logArg="$1"
+           elif [ -z "$envArg" ]; then
+             envArg="$1"
+           fi
          fi
       ;;
   esac
   shift
 done
+
+# Normalize: anything other than critical, debug, or off is treated as normal
+if [ -z "$logArg" ]; then
+  logArg="normal"
+fi
+if [ "$logArg" != "critical" ] && [ "$logArg" != "debug" ] && [ "$logArg" != "off" ]; then
+  logArg="normal"
+fi
+
+# Rewrite the log level in Rocket.toml (read at run time, so the change is left in place)
+rocketFile="../../Rocket.toml"
+
+echo "  Using log level \"$logArg\""
+sed -i '' "s|^log_level = \"[^\"]*\"|log_level = \"$logArg\"|" "$rocketFile"
 
 # Normalize: anything other than dev or qa is treated as main
 if [ -z "$envArg" ]; then
@@ -35,10 +52,10 @@ fi
 # For main, Cargo.toml already has the correct version — no replacement needed
 cargoFile="../../local_server/Cargo.toml"
 cargoBackup="../../local_server/Cargo.toml.bak"
-didRewrite=0
+didRewriteCargo=0
 
 restore_cargo() {
-  if [ "$didRewrite" -eq 1 ] && [ -f "$cargoBackup" ]; then
+  if [ "$didRewriteCargo" -eq 1 ] && [ -f "$cargoBackup" ]; then
     cp "$cargoBackup" "$cargoFile"
     rm "$cargoBackup"
   fi
@@ -54,31 +71,17 @@ if [ "$envArg" != "main" ]; then
   echo "  Using pankosmia_web version $targetVersion for environment \"$envArg\""
   cp "$cargoFile" "$cargoBackup"
   sed -i '' "s|pankosmia_web = \"=[^\"]*\"|pankosmia_web = \"=$targetVersion\"|" "$cargoFile"
-  didRewrite=1
+  didRewriteCargo=1
 else
   echo "  Using pankosmia_web version from Cargo.toml (main)"
 fi
 
 # Assign default value if -s is not present
-if [ -z ${askIfOff+x} ]; then # serverOff is unset
+if [ -z ${askIfOff+x} ]; then # askIfOff is unset
   askIfOff=-yes
 fi
 
-# Assign default value if -d is not present
-if [ -z ${debugServer+x} ]; then # debugServer is unset
-  debugServer=-no
-  buildCommand=(cargo build --release)
-  search=local_server/target/debug
-  replace=local_server/target/release
-  serverType=release
-elif [[ $debugServer =~ ^(-d) ]]; then
-  buildCommand=(cargo build)
-  search=local_server/target/release
-  replace=local_server/target/debug
-  serverType=debug
-fi
-
-# Do not ask if the server is off if the -s $1 or $2 positional argument is provided
+# Do not ask if the server is off if the -s argument is provided
 if ! [[ $askIfOff =~ ^(-s) ]]; then
   while true; do
     read "choice?Is the server off? [Y/n]: "
@@ -108,18 +111,14 @@ if [ ! -f ../../buildSpec.json ] || [ ! -f ../../globalBuildResources/i18nPatch.
   echo "  +-----------------------------------------------------------------------------+"
   echo "  | Config files were rebuilt by \`./app_setup.zsh\` as one or more were missing. |"
   echo "  +-----------------------------------------------------------------------------+"
-  echo 
+  echo
 fi
 
-# Ensure buildSpec.json has the location for the indicated server build type
-configFile=../../buildSpec.json
-tmpFile=../../buildSpec.bak
-cp $configFile $tmpFile
-sed -i '' "s|$search|$replace|g" "$configFile"
-
-echo "Building local $serverType server at /$replace ..."
+# Build the rust server (always release)
+echo "Building local Release server at /local_server/target/release ..."
 cd ../../local_server
-OPENSSL_STATIC=yes "${buildCommand[@]}"
+echo "cargo build --release"
+OPENSSL_STATIC=yes cargo build --release
 cd ../macos/scripts
 
 # Cargo.toml is restored by the EXIT trap

--- a/macos/scripts/clean.zsh
+++ b/macos/scripts/clean.zsh
@@ -37,7 +37,7 @@ if [ -d ../build ]; then
   rm -rf ../build
 fi
 
-if [ -f ../../local_server/target/release/local_server ] || [ -f ../../local_server/target/debug/local_server ]; then
+if [ -f ../../local_server/target/release/local_server ]; then
     echo
     echo
     echo "Cleaning local server"

--- a/macos/scripts/run.zsh
+++ b/macos/scripts/run.zsh
@@ -1,60 +1,37 @@
 #!/usr/bin/env zsh
 
 # Run from pankosmia/[this-repo's-name]/macos/scripts directory by:  ./run.zsh
-# with the optional arguments of: `./run.zsh -s` to pre-specify that the server is off.
-# or the optional arguments of: `./run.bsh -s` to run server in debug mode.
+# with the optional argument of: `./run.zsh -s` to pre-specify that the server is off.
 
 set -e
 set -u
 
 echo
 
-# Do not ask if the server is off if the -s positional argument is provided in either #1 or #2
-# Debug server if the -d positional argument is provided in either #1 or #2
+# Do not ask if the server is off if the -s argument is provided
 while [[ "$#" -gt 0 ]]
   do case $1 in
       -s) askIfOff="$1" # -s means "no"
       ;;
-      -d) debugServer="$1" # -d = "yes"
   esac
   shift
 done
 
 # Assign default value if -s is not present
-if [ -z ${askIfOff+x} ]; then # serverOff is unset
+if [ -z ${askIfOff+x} ]; then # askIfOff is unset
   askIfOff=-yes
 fi
 
-missingServer() {
+if [ ! -f ../../local_server/target/release/local_server ]; then
   echo
   echo "      Exiting..."
   echo
-  echo "      The $1 server does not exist. Run \`$2\`, then re-run this script."
+  echo "      The local server does not exist. Run \`./build_server.zsh\`, then re-run this script."
   echo
   exit
-}
-
-# Assign default value if -s is not present
-if [ -z ${debugServer+x} ]; then # debugServer is unset
-  debugServer=-no
-  search=local_server/target/debug
-  replace=local_server/target/release
-  serverType=release
-  script=".\\\\build_server.bat"
-  if [ ! -f ../../local_server/target/release/local_server ]; then
-    missingServer "$serverType" "$script"
-  fi
-elif [[ $debugServer =~ ^(-d) ]]; then
-  search=local_server/target/release
-  replace=local_server/target/debug
-  serverType=debug
-  script=".\\\\build_server.bat -d"
-    if [ ! -f ../../local_server/target/debug/local_server ]; then
-    missingServer "$serverType" "$script"
-  fi
 fi
 
-# Do not ask if the server is off if the -s $1 or $2 positional argument is provided
+# Do not ask if the server is off if the -s argument is provided
 if ! [[ $askIfOff =~ ^(-s) ]]; then
   while true; do
     read "choice?Is the server off? [Y/n]: "
@@ -87,12 +64,6 @@ if [ ! -f ../../buildSpec.json ] || [ ! -f ../../globalBuildResources/i18nPatch.
   echo
 fi
 
-# Ensure buildSpec.json has the location for the indicated server build type
-configFile=../../buildSpec.json
-tmpFile=../../buildSpec.bak
-cp $configFile $tmpFile
-sed -i '' "s|$search|$replace|g" "$configFile"
-
 # set available port environment variable (exported as $ROCKET_PORT )
 source ../buildResources/find_free_port.sh
 echo "Serving on port $ROCKET_PORT..."
@@ -112,7 +83,7 @@ fi
 cd ../build
 
 echo
-echo "Running with local server in $serverType mode... When ready to stop this server, press Ctrl-C."
+echo "Running with local server in release mode... When ready to stop this server, press Ctrl-C."
 echo "       If Ctrl-Z (suspend) is used by accident, then run \`killall -9 \"server.bin\"\` or Force Quit from the Activity Monitor,"
 echo "       or to resume run \`fg\` for the last suspended process, otherwise \`fg \"./run.zsh\"\`."
 echo

--- a/package-lock.json
+++ b/package-lock.json
@@ -338,9 +338,10 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },

--- a/windows/scripts/build_server.bat
+++ b/windows/scripts/build_server.bat
@@ -39,37 +39,25 @@ if /I not "%logArg%"=="critical" if /I not "%logArg%"=="debug" if /I not "%logAr
   set "logArg=normal"
 )
 
-REM For critical, debug, or off, back up Rocket.toml and rewrite the log level
-REM For normal, Rocket.toml already has the correct version — no replacement needed
+REM Rewrite the log level in Rocket.toml (read at run time, so the change is left in place)
 set "rocketFile=..\..\Rocket.toml"
-set "rocketBackup=..\..\Rocket.toml.bak"
-set "didRewriteRocket=0"
 
-if /I not "%logArg%"=="normal" (
-  setlocal enabledelayedexpansion
-  echo.
-  echo   Using log level "%logArg%"
+setlocal enabledelayedexpansion
+echo.
+echo   Using log level "%logArg%"
 
-  copy "%rocketFile%" "%rocketBackup%" >nul
-
-  set "rocketTmp=..\..\Rocket.toml.tmp"
-  (for /f "usebackq tokens=*" %%a in ("!rocketBackup!") do (
-    set "line=%%a"
-    echo !line! | findstr /C:"log_level" >nul
-    if !errorlevel! equ 0 (
-      echo log_level = "%logArg%"
-    ) else (
-      echo(!line!
-    )
-  )) > "!rocketTmp!"
-  move /y "!rocketTmp!" "!rocketFile!" >nul
-
-  endlocal
-  set "didRewriteRocket=1"
-) else (
-  echo.
-  echo   Using log level version from Rocket.toml ^(normal^)
-)
+set "rocketTmp=..\..\Rocket.toml.tmp"
+(for /f "usebackq tokens=*" %%a in ("!rocketFile!") do (
+  set "line=%%a"
+  echo !line! | findstr /C:"log_level" >nul
+  if !errorlevel! equ 0 (
+    echo log_level = "%logArg%"
+  ) else (
+    echo(!line!
+  )
+)) > "!rocketTmp!"
+move /y "!rocketTmp!" "!rocketFile!" >nul
+endlocal
 
 REM Normalize: anything other than dev or qa is treated as main
 if not defined envArg (
@@ -148,12 +136,6 @@ echo.
 echo      If the server is on, turn it off by exiting the terminal window or app where it is running, then re-run this script.
 echo.
 
-REM Restore Rocket.toml if it was rewritten
-if "%didRewriteRocket%"=="1" (
-  copy "..\..\Rocket.toml.bak" "..\..\Rocket.toml" >nul
-  del "..\..\Rocket.toml.bak"
-)
-
 REM Restore Cargo.toml if it was rewritten
 if "%didRewriteCargo%"=="1" (
   copy "..\..\local_server\Cargo.toml.bak" "..\..\local_server\Cargo.toml" >nul
@@ -183,12 +165,6 @@ echo "cargo build --release"
 cargo build --release
 set "buildResult=%errorlevel%"
 cd ..\windows\scripts
-
-REM Restore Rocket.toml if it was rewritten
-if "%didRewriteRocket%"=="1" (
-  copy "..\..\Rocket.toml.bak" "..\..\Rocket.toml" >nul
-  del "..\..\Rocket.toml.bak"
-)
 
 REM Restore Cargo.toml if it was rewritten
 if "%didRewriteCargo%"=="1" (

--- a/windows/scripts/build_server.bat
+++ b/windows/scripts/build_server.bat
@@ -1,9 +1,9 @@
 @echo off
 REM Run from pankosmia\[this-repo's-name]\windows\scripts directory in powershell or command by:  .\build_server.bat
 
-REM Do not ask if the server is off if the -s positional argument is provided
-REM Debug server if the -d positional argument is provided
-REM Specify environment as first non-flag positional argument: dev, qa, or main (default: main)
+REM Do not ask if the server is off if the -s argument is provided
+REM Specify environment as an optional non-flag argument: dev, qa, or main (default: main)
+REM Specify log level as as an optional non-flag argument: critical, normal, debug, or off (default: normal)
 set "envArg="
 set "logArg="
 :loop

--- a/windows/scripts/build_server.bat
+++ b/windows/scripts/build_server.bat
@@ -5,6 +5,7 @@ REM Do not ask if the server is off if the -s positional argument is provided
 REM Debug server if the -d positional argument is provided
 REM Specify environment as first non-flag positional argument: dev, qa, or main (default: main)
 set "envArg="
+set "logArg="
 :loop
 IF "%~1"=="" (
   goto :continue
@@ -14,10 +15,11 @@ IF "%~1"=="-s" (
   shift
   goto :loop
 )
-IF "%~1"=="-d" (
-  set "debugServer=%~1"
-  shift
-  goto :loop
+IF not defined logArg (
+  IF "%~1"=="critical" ( set "logArg=critical" & shift & goto :loop )
+  IF "%~1"=="normal"   ( set "logArg=normal"   & shift & goto :loop )
+  IF "%~1"=="debug"    ( set "logArg=debug"     & shift & goto :loop )
+  IF "%~1"=="off"      ( set "logArg=off"       & shift & goto :loop )
 )
 IF not defined envArg (
   IF "%~1"=="dev" set "envArg=dev"
@@ -28,6 +30,46 @@ shift
 goto :loop
 
 :continue
+
+REM Normalize: anything other than critical, debug, or off is treated as normal
+if not defined logArg (
+  set "logArg=normal"
+)
+if /I not "%logArg%"=="critical" if /I not "%logArg%"=="debug" if /I not "%logArg%"=="off" (
+  set "logArg=normal"
+)
+
+REM For critical, debug, or off, back up Rocket.toml and rewrite the log level
+REM For normal, Rocket.toml already has the correct version — no replacement needed
+set "rocketFile=..\..\Rocket.toml"
+set "rocketBackup=..\..\Rocket.toml.bak"
+set "didRewriteRocket=0"
+
+if /I not "%logArg%"=="normal" (
+  setlocal enabledelayedexpansion
+  echo.
+  echo   Using log level "%logArg%"
+
+  copy "%rocketFile%" "%rocketBackup%" >nul
+
+  set "rocketTmp=..\..\Rocket.toml.tmp"
+  (for /f "usebackq tokens=*" %%a in ("!rocketBackup!") do (
+    set "line=%%a"
+    echo !line! | findstr /C:"log_level" >nul
+    if !errorlevel! equ 0 (
+      echo log_level = "%logArg%"
+    ) else (
+      echo(!line!
+    )
+  )) > "!rocketTmp!"
+  move /y "!rocketTmp!" "!rocketFile!" >nul
+
+  endlocal
+  set "didRewriteRocket=1"
+) else (
+  echo.
+  echo   Using log level version from Rocket.toml ^(normal^)
+)
 
 REM Normalize: anything other than dev or qa is treated as main
 if not defined envArg (
@@ -41,7 +83,7 @@ REM For dev and qa, back up Cargo.toml and rewrite the pankosmia_web version
 REM For main, Cargo.toml already has the correct version — no replacement needed
 set "cargoFile=..\..\local_server\Cargo.toml"
 set "cargoBackup=..\..\local_server\Cargo.toml.bak"
-set "didRewrite=0"
+set "didRewriteCargo=0"
 
 if /I not "%envArg%"=="main" (
   setlocal enabledelayedexpansion
@@ -75,29 +117,15 @@ if /I not "%envArg%"=="main" (
   move /y "!cargoTmp!" "!cargoFile!" >nul
 
   endlocal
-  set "didRewrite=1"
+  set "didRewriteCargo=1"
 ) else (
   echo.
   echo   Using pankosmia_web version from Cargo.toml ^(main^)
 )
 
 REM Assign default value if -s is not present
-if not defined %askIfOff (
+if not defined askIfOff (
   set "askIfOff=-yes"
-)
-
-REM Assign default value if -d is not present
-if not defined %debugServer (
-  set "debugServer=-no"
-  set "buildCommand=cargo build --release"
-  set "search=local_server/target/debug"
-  set "replace=local_server/target/release"
-  set "serverType=release"
-) else if "%debugServer%"=="-d" (
-  set "buildCommand=cargo build"
-  set "search=local_server/target/release"
-  set "replace=local_server/target/debug"
-  set "serverType=debug"
 )
 
 echo.
@@ -119,8 +147,15 @@ echo      Exiting...
 echo.
 echo      If the server is on, turn it off by exiting the terminal window or app where it is running, then re-run this script.
 echo.
+
+REM Restore Rocket.toml if it was rewritten
+if "%didRewriteRocket%"=="1" (
+  copy "..\..\Rocket.toml.bak" "..\..\Rocket.toml" >nul
+  del "..\..\Rocket.toml.bak"
+)
+
 REM Restore Cargo.toml if it was rewritten
-if "%didRewrite%"=="1" (
+if "%didRewriteCargo%"=="1" (
   copy "..\..\local_server\Cargo.toml.bak" "..\..\local_server\Cargo.toml" >nul
   del "..\..\local_server\Cargo.toml.bak"
 )
@@ -129,49 +164,34 @@ exit
 :server_off
 
 if not exist ..\..\buildSpec.json set "runSetup=1"
-if not exist ..\..\globalBuildResources\i18nPatch.json "set runSetup=1"
-if not exist ..\..\globalBuildResources\product.json "set runSetup=1"
-if not exist ..\buildResources\setup\app_setup.json "set runSetup=1"
-if defined %runSetup (
+if not exist ..\..\globalBuildResources\i18nPatch.json set "runSetup=1"
+if not exist ..\..\globalBuildResources\product.json set "runSetup=1"
+if not exist ..\buildResources\setup\app_setup.json set "runSetup=1"
+if defined runSetup (
   cmd /c .\app_setup.bat
   echo.
   echo   +-----------------------------------------------------------------------------+
-  echo   ^| Config files were rebuilt by `./app_setup.bsh` as one or more were missing. ^|
+  echo   ^| Config files were rebuilt by `.\app_setup.bat` as one or more were missing. ^|
   echo   +-----------------------------------------------------------------------------+
   echo.
 )
 
-REM Ensure buildSpec.json has the location for the indicated server build type
-@echo off
-setlocal enabledelayedexpansion
-
-set "configFile=..\..\buildSpec.json"
-set "tmpFile=..\..\buildSpec.bak"
-copy %configFile% %tmpFile%
-
-
-(for /f "tokens=*" %%a in ('type "%tmpFile%" ^| findstr /n "^"') do (
-    set "line=%%a"
-    set "line=!line:*:=!"
-
-    if defined line (
-        set "line=!line:%search%=%replace%!"
-        echo(!line!
-    ) else echo.
-)) > "%configFile%"
-
-endlocal
-
 REM Build the rust server of the specified build type
-echo "Building local %serverType% server at /%replace% ..."
+echo "Building local Release server at /local_server/target/release ..."
 cd ..\..\local_server
-echo "%buildCommand%"
-%buildCommand%
+echo "cargo build --release"
+cargo build --release
 set "buildResult=%errorlevel%"
 cd ..\windows\scripts
 
+REM Restore Rocket.toml if it was rewritten
+if "%didRewriteRocket%"=="1" (
+  copy "..\..\Rocket.toml.bak" "..\..\Rocket.toml" >nul
+  del "..\..\Rocket.toml.bak"
+)
+
 REM Restore Cargo.toml if it was rewritten
-if "%didRewrite%"=="1" (
+if "%didRewriteCargo%"=="1" (
   copy "..\..\local_server\Cargo.toml.bak" "..\..\local_server\Cargo.toml" >nul
   del "..\..\local_server\Cargo.toml.bak"
 )

--- a/windows/scripts/clean.bat
+++ b/windows/scripts/clean.bat
@@ -3,9 +3,12 @@ REM Run from pankosmia\[this-repo's-name]\windows\scripts directory in powershel
 REM Optional argument: .\clean.bat -s
 REM To pre-confirm the server is off, so as to not be asked.
 
+set "askIfOff="
+IF "%~1"=="-s" set "askIfOff=-s"
+
 echo.
 :choice
-IF "%~1"=="-s" (
+IF "%askIfOff%"=="-s" (
   goto :server_off
 ) ELSE (
   set /P "c=Is the server off? [Y/n]: "
@@ -32,12 +35,7 @@ if exist ..\build (
   rmdir ..\build /s /q
 )
 
-set "cleanServer=false"
-
-if exist ..\..\local_server\target\release\local_server.exe set "cleanServer=true"
-if exist ..\..\local_server\target\debug\local_server.exe set "cleanServer=true"
-
-if "%cleanServer%"=="true" (
+if exist ..\..\local_server\target\release\local_server.exe (
   echo Cleaning local server
   cd ..\..\local_server
   cargo clean

--- a/windows/scripts/run.bat
+++ b/windows/scripts/run.bat
@@ -1,17 +1,13 @@
 @echo off
 REM Run from pankosmia\[this-repo's-name]\windows\scripts directory in powershell or command by:  .\run.bat
 REM Optional argument: `.\run.bat -s` to pre-confirm the server is off, so as to not be asked.
-REM Optional argument: `.\run.bat -d` to run the server in debug mode.
 
-REM Do not ask if the server is off if the -s positional argument is provided in either #1 or #2
-REM Debug server if the -d positional argument is provided in either #1 or #2
+REM Do not ask if the server is off if the -s positional argument is provided
 :loop
 IF "%~1"=="" (
   goto :continue
 ) ELSE IF "%~1"=="-s" (
   set "askIfOff=%~1"
-) ELSE IF "%~1"=="-d" (
-  set "debugServer=%~1"
 )
 shift
 goto :loop
@@ -19,43 +15,18 @@ goto :loop
 :continue
 
 REM Assign default value if -s is not present
-if not defined %askIfOff (
+if not defined askIfOff (
   set "askIfOff=-yes"
 )
 
-REM Assign default value if -d is not present
-if not defined %debugServer (
-  set "debugServer=-no"
-  set "search=local_server/target/debug"
-  set "replace=local_server/target/release"
-  set "serverType=release"
-  if not exist ..\..\local_server\target\release\local_server.exe (
-    set "script=.\build_server.bat"
-    goto :missing_server
-  ) else (
-    goto :server_build_exists
-  )
-) else if "%debugServer%"=="-d" (
-  set "search=local_server/target/release"
-  set "replace=local_server/target/debug"
-  set "serverType=debug"
-  if not exist ..\..\local_server\target\debug\local_server.exe (
-    set "script=.\build_server.bat -d"
-    goto :missing_server
-  ) else (
-    goto :server_build_exists
-  )
+if not exist ..\..\local_server\target\release\local_server.exe (
+  echo.
+  echo      Exiting...
+  echo.
+  echo      The local server does not exist. Run `.\build_server.bat`, then re-run this script.
+  echo.
+  exit
 )
-
-:missing_server
-echo.
-echo      Exiting...
-echo.
-echo      The %serverType% server does not exist. Run `%script%`, then re-run this script.
-echo.
-exit
-
-:server_build_exists
 
 echo.
 :choice
@@ -85,34 +56,14 @@ if not exist ..\..\buildSpec.json set "runSetup=1"
 if not exist ..\..\globalBuildResources\i18nPatch.json set "runSetup=1"
 if not exist ..\..\globalBuildResources\product.json set "runSetup=1"
 if not exist ..\buildResources\setup\app_setup.json set "runSetup=1"
-if defined %runSetup (
+if defined runSetup (
   cmd /c .\app_setup.bat
   echo.
   echo   +-----------------------------------------------------------------------------+
-  echo   ^| Config files were rebuilt by `./app_setup.bsh` as one or more were missing. ^|
+  echo   ^| Config files were rebuilt by `.\app_setup.bat` as one or more were missing. ^|
   echo   +-----------------------------------------------------------------------------+
   echo.
 )
-
-REM Ensure buildSpec.json has the location for the indicated server build type
-setlocal enabledelayedexpansion
-
-set "configFile=..\..\buildSpec.json"
-set "tmpFile=..\..\buildSpec.bak"
-copy %configFile% %tmpFile%
-
-
-(for /f "tokens=*" %%a in ('type "%tmpFile%" ^| findstr /n "^"') do (
-    set "line=%%a"
-    set "line=!line:*:=!"
-
-    if defined line (
-        set "line=!line:%search%=%replace%!"
-        echo(!line!
-    ) else echo.
-)) > "%configFile%"
-
-endlocal
 
 REM set available port environment variable (returned as %ROCKET_PORT% )
 call ..\buildResources\find_free_port.bat
@@ -126,7 +77,7 @@ if not exist ..\build (
   echo Assembling build environment...
   node build.js
 )
-echo Running with local server in %serverType% mode...
+echo Running with local server in release mode...
 cd ..\build
 SET "APP_RESOURCES_DIR=.\lib\"
 start "" cmd /k ".\bin\server.exe"


### PR DESCRIPTION
## Changes
| Out with the OLD | In with the NEW (this PR) |
|---|---|
| <img width="333" height="432" alt="image" src="https://github.com/user-attachments/assets/2ee6cd33-89f5-4c95-8f95-d261529339b7" /><br />default: release<br />&nbsp; | <img width="322" height="447" alt="image" src="https://github.com/user-attachments/assets/2e0bae4c-4b8c-4bbe-bda3-50ecb56df3b8" /><br />_GHA only_ default: critical<br />&nbsp; |
| `build_server.[ bat \| bsh \| zsh ] -d` re-writes server path in `buildSpec.json` | `build_server.[ bat \| bsh \| zsh ] [ critical \| normal (default) \| debug \| off ]` re-writes log level in `Rocket.toml` |
| `clean.[ bat \| bsh \| zsh ]` checks for a release server and/or a debug server to clean | `clean.[ bat \| bsh \| zsh ]` only checks for a release server to clean |
| `run.[ bat \| bsh \| zsh ]  -d` ensures `buildSpec.json` still has the debug server location | No more `-d` argument or server location check/fix |

## Note
- `build_server.[ bat \| bsh \| zsh ]` re-writes log-level in `Rocket.toml` to "normal" (default).  Currently all `Rocket.toml`'s are already set to "normal", so this will not register as a pending change.
- A dev can also edit the log level manually in their `Rocket.toml` file, and their edit will be respected on use of `run.[ bat \| bsh \| zsh ]`.  However, their manual log level edit will be overwritten on their next use of `build_server.[ bat \| bsh \| zsh ] [ critical \| normal (default) \| debug \| off ]
- Because `build_server.[ bat \| bsh \| zsh ] [ critical \| normal (default) \| debug \| off ]` re-writes log-level in `Rocket.toml`, it is possible that a dev could see `Rocket.toml` as having a pending change.
- GHA rewrites the log level in `Rocket.toml` to match its input, with the default being "critical".