### PR TITLE
Remove old config on install

### DIFF
--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -242,8 +242,8 @@ jobs:
             cd ./releases/macos
             echo "Found arm64 release:"
             ls -als *.pkg
-            PKG_NAME_ARM=$(ls *-standalone-arm64*.pkg | head -n 1)
-            echo "PKG_NAME_ARM=$PKG_NAME_ARM" >> $GITHUB_ENV
+            ELECTRONITE_PKG_NAME_ARM=$(ls *-standalone-arm64*.pkg | head -n 1)
+            echo "ELECTRONITE_PKG_NAME_ARM=$ELECTRONITE_PKG_NAME_ARM" >> $GITHUB_ENV
             cd ../..
           else
             echo "No arm64 .pkg files found in ./releases/macos"
@@ -255,27 +255,27 @@ jobs:
             cd ./releases/macos
             echo "Found intel64 release:"
             ls -als *.pkg
-            PKG_NAME_INTEL=$(ls *-standalone-intel64*.pkg | head -n 1)
-            echo "PKG_NAME_INTEL=$PKG_NAME_INTEL" >> $GITHUB_ENV
+            ELECTRONITE_PKG_NAME_INTEL=$(ls *-standalone-intel64*.pkg | head -n 1)
+            echo "ELECTRONITE_PKG_NAME_INTEL=$ELECTRONITE_PKG_NAME_INTEL" >> $GITHUB_ENV
             cd ../..
           else
             echo "No intel64 .pkg files found in ./releases/macos"
           fi
 
       - name: Upload electronite arm64 artifacts
-        if: env.PKG_NAME_ARM != ''
+        if: env.ELECTRONITE_PKG_NAME_ARM != ''
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PKG_NAME_ARM }}
-          path: ./releases/macos/${{ env.PKG_NAME_ARM }}
+          name: ${{ env.ELECTRONITE_PKG_NAME_ARM }}
+          path: ./releases/macos/${{ env.ELECTRONITE_PKG_NAME_ARM }}
           if-no-files-found: error
           retention-days: 90
 
       - name: Upload electronite intel64 artifacts
-        if: env.PKG_NAME_INTEL != ''
+        if: env.ELECTRONITE_PKG_NAME_INTEL != ''
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PKG_NAME_INTEL }}
-          path: ./releases/macos/${{ env.PKG_NAME_INTEL }}
+          name: ${{ env.ELECTRONITE_PKG_NAME_INTEL }}
+          path: ./releases/macos/${{ env.ELECTRONITE_PKG_NAME_INTEL }}
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -163,6 +163,7 @@ jobs:
           echo "APP_NAME: ${{ env.APP_NAME }}"
           echo "APP_VERSION: ${{ env.APP_VERSION }}"
           echo "FILE_APP_NAME: ${{ env.FILE_APP_NAME }}"
+          echo "APP_SHORT_NAME: ${{ env.APP_SHORT_NAME }}"
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /O"..\..\releases\windows" makeInstall.iss
 
       # Get names for exe artifacts

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -89,7 +89,7 @@ jobs:
           echo "APP_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "APP_VERSION=$version"
 
-      # Set APP_NAME from app_config.env, and use it to define FILE_APP_NAME
+      # Set APP_NAME and APP_SHORT_NAME from app_config.env, and define FILE_APP_NAME
       - name: Extract APP_NAME from app_config.env
         id: get_app_name
         run: |
@@ -102,7 +102,10 @@ jobs:
           $fileAppName = $appName.ToLower().Replace(" ","-").Replace("'","")   # Use lower case app name in filename and replace spaces with dashes (-) and remove single apostrophes (')
           echo "FILE_APP_NAME=$fileAppName" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "FILE_APP_NAME=$fileAppName"
-  
+          $appShortNameLine = Get-Content $envFile | Where-Object { $_ -match '^APP_SHORT_NAME\s*=' }
+          $appShortName = $appShortNameLine -replace ".*=(.*)", '$1'
+          echo "APP_SHORT_NAME=$appShortName" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "APP_SHORT_NAME=$appShortName"
       # Install the repository
       - name: Install this repo
         run: npm ci

--- a/linux/buildResources/preinst
+++ b/linux/buildResources/preinst
@@ -5,7 +5,17 @@ set -e
 for USER_HOME in /home/*; do
     CONFIG_DIR="$USER_HOME/pankosmia/{APP_SHORT_NAME}"
     if [ -d "$CONFIG_DIR" ]; then
-        echo "Removing prior config directory: $CONFIG_DIR"
-        rm -rf "$CONFIG_DIR"
+        if [ -d "$CONFIG_DIR/webfonts" ]; then
+            echo "Removing prior webfonts config directory: $CONFIG_DIR/webfonts"
+            rm -rf "$CONFIG_DIR/webfonts"
+        fi
+        if [ -d "$CONFIG_DIR/temp" ]; then
+            echo "Removing prior temp directory: $CONFIG_DIR/temp"
+            rm -rf "$CONFIG_DIR/temp"
+        fi
+        if [ -d "$CONFIG_DIR/i18n.json" ]; then
+            echo "Removing prior config file: $CONFIG_DIR/i18n.json"
+            rm "$CONFIG_DIR/i18n.json"
+        fi
     fi
 done

--- a/linux/buildResources/preinst
+++ b/linux/buildResources/preinst
@@ -1,13 +1,7 @@
 #!/bin/bash
 set -e
 
-# Setting variables
-BASE_DIR=/opt/{PACKAGE_NAME}
-APP_DIR=$BASE_DIR
-SETTINGS_FILE=$BASE_DIR/app_config.env
-
-source $SETTINGS_FILE
-CONFIG_DIR="~/pankosmia/${APP_SHORT_NAME}"
+CONFIG_DIR="~/pankosmia/{APP_SHORT_NAME}"
 
 if [ -d "$CONFIG_DIR" ]; then
     echo "Removing prior config directory: $CONFIG_DIR"

--- a/linux/buildResources/preinst
+++ b/linux/buildResources/preinst
@@ -13,9 +13,9 @@ for USER_HOME in /home/*; do
             echo "Removing prior temp directory: $CONFIG_DIR/temp"
             rm -rf "$CONFIG_DIR/temp"
         fi
-        if [ -d "$CONFIG_DIR/i18n.json" ]; then
+        if [ -f "$CONFIG_DIR/i18n.json" ]; then
             echo "Removing prior config file: $CONFIG_DIR/i18n.json"
-            rm "$CONFIG_DIR/i18n.json"
+            rm -f "$CONFIG_DIR/i18n.json"
         fi
     fi
 done

--- a/linux/buildResources/preinst
+++ b/linux/buildResources/preinst
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Setting variables
+BASE_DIR=/opt/{PACKAGE_NAME}
+APP_DIR=$BASE_DIR
+SETTINGS_FILE=$BASE_DIR/app_config.env
+
+source $SETTINGS_FILE
+CONFIG_DIR="~/pankosmia/${APP_SHORT_NAME}"
+
+if [ -d "$CONFIG_DIR" ]; then
+    echo "Removing prior config directory: $CONFIG_DIR"
+    rm -rf "$CONFIG_DIR"
+fi

--- a/linux/buildResources/preinst
+++ b/linux/buildResources/preinst
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -e
 
-CONFIG_DIR="~/pankosmia/{APP_SHORT_NAME}"
-
-if [ -d "$CONFIG_DIR" ]; then
-    echo "Removing prior config directory: $CONFIG_DIR"
-    rm -rf "$CONFIG_DIR"
-fi
+# Iterate over user home directories
+for USER_HOME in /home/*; do
+    CONFIG_DIR="$USER_HOME/pankosmia/{APP_SHORT_NAME}"
+    if [ -d "$CONFIG_DIR" ]; then
+        echo "Removing prior config directory: $CONFIG_DIR"
+        rm -rf "$CONFIG_DIR"
+    fi
+done

--- a/linux/install/makeAllInstallsElectronite.bsh
+++ b/linux/install/makeAllInstallsElectronite.bsh
@@ -24,9 +24,17 @@ devRun="${1:-no}" # This is a development viewer run if $1 is -d
 # This script uses the APP_NAME environment variables as defined in app_config.env
 source ../../app_config.env
 
+EMSG="environment variable is not set in makeAllInstallsElectronite.bsh."
+
 # Confirm the APP_NAME environment variables is set
 if [ -z "$APP_NAME" ]; then
-    echo "Error: APP_NAME environment variable is not set."
+    echo "Error: APP_NAME $EMSG"
+    exit 1
+fi
+
+# Confirm the APP_SHORT_NAME environment variables is set
+if [ -z "$APP_SHORT_NAME" ]; then
+    echo "Error: APP_SHORT_NAME $EMSG"
     exit 1
 fi
 
@@ -42,6 +50,8 @@ echo "APP_NAME=$APP_NAME"
 export APP_NAME="$APP_NAME"
 echo "APP_VERSION=$APP_VERSION"
 export APP_VERSION="$APP_VERSION"
+echo "APP_SHORT_NAME=$APP_SHORT_NAME" 
+export APP_SHORT_NAME="$APP_SHORT_NAME"
 
 ElectronArm64="https://github.com/unfoldingWord/electronite/releases/download/v37.1.0-graphite/electronite-v37.1.0-graphite-linux-arm64.zip"
 ElectronIntel64="https://github.com/unfoldingWord/electronite/releases/download/v37.1.0-graphite/electronite-v37.1.0-graphite-linux-x64.zip"

--- a/linux/install/makeInstallElectronite.bsh
+++ b/linux/install/makeInstallElectronite.bsh
@@ -32,21 +32,22 @@
 # Output:
 #   Creates installer package at: ../releases/linux/<app-name>_installer_<arch>_<version>.pkg
 
+EMSG="environment variable is not set in makeInstallElectronite.bsh."
 # Check if APP_NAME environment variable is set
 if [ -z "$APP_NAME" ]; then
-    echo "Error: APP_NAME environment variable is not set."
+    echo "Error: APP_NAME $EMSG"
     exit 1
 fi
 
 # Check if APP_VERSION environment variable is set
 if [ -z "$APP_VERSION" ]; then
-    echo "Error: APP_VERSION environment variable is not set."
+    echo "Error: APP_VERSION $EMSG"
     exit 1
 fi
 
 # Check if FILE_APP_NAME environment variable is set
 if [ -z "$FILE_APP_NAME" ]; then
-    echo "Error: FILE_APP_NAME environment variable is not set."
+    echo "Error: FILE_APP_NAME $EMSG"
     exit 1
 fi
 

--- a/linux/scripts/bundle_viewer.bsh
+++ b/linux/scripts/bundle_viewer.bsh
@@ -73,7 +73,7 @@ sed -i "s|{PACKAGE_VERSION}|$APP_VERSION|g; s|{PACKAGE_NAME}|$PACKAGE_NAME|g; s|
 
 # Copy preinst to DEBIAN package
 cp $FROM_DIR/linux/buildResources/preinst $TO_DIR/DEBIAN
-sed -i "s|{APP_SHORT_NAME}|$APP_SHORT_NAME|g; $TO_DIR/DEBIAN/preinst
+sed -i "s|{APP_SHORT_NAME}|$APP_SHORT_NAME|g" $TO_DIR/DEBIAN/preinst
 chmod +x $TO_DIR/DEBIAN/preinst
 
 # Finally, build the package and write it to the Release directory

--- a/linux/scripts/bundle_viewer.bsh
+++ b/linux/scripts/bundle_viewer.bsh
@@ -71,6 +71,10 @@ cp $FROM_DIR/linux/buildResources/control $TO_DIR/DEBIAN
 INSTALLED_SIZE=`du -c $TO_DIR | grep total | cut -f1`
 sed -i "s|{PACKAGE_VERSION}|$APP_VERSION|g; s|{PACKAGE_NAME}|$PACKAGE_NAME|g; s|{INSTALLED_SIZE}|$INSTALLED_SIZE|g" $TO_DIR/DEBIAN/control
 
+# Copy preinst to DEBIAN package
+cp $FROM_DIR/linux/buildResources/preinst $TO_DIR/DEBIAN
+chmod +x $TO_DIR/DEBIAN/preinst
+
 # Finally, build the package and write it to the Release directory
 cd /tmp
 dpkg-deb --root-owner-group --build $PACKAGE_NAME $RELEASE_DIR/$PACKAGE_NAME-linux-standalone-intel64-$APP_VERSION.deb

--- a/linux/scripts/bundle_viewer.bsh
+++ b/linux/scripts/bundle_viewer.bsh
@@ -73,6 +73,7 @@ sed -i "s|{PACKAGE_VERSION}|$APP_VERSION|g; s|{PACKAGE_NAME}|$PACKAGE_NAME|g; s|
 
 # Copy preinst to DEBIAN package
 cp $FROM_DIR/linux/buildResources/preinst $TO_DIR/DEBIAN
+sed -i "s|{APP_SHORT_NAME}|$APP_SHORT_NAME|g; $TO_DIR/DEBIAN/preinst
 chmod +x $TO_DIR/DEBIAN/preinst
 
 # Finally, build the package and write it to the Release directory

--- a/macos/buildResources/preinstall
+++ b/macos/buildResources/preinstall
@@ -5,7 +5,17 @@ set -e
 for USER_HOME in /Users/*; do
     CONFIG_DIR="$USER_HOME/pankosmia/{APP_SHORT_NAME}"
     if [ -d "$CONFIG_DIR" ]; then
-        echo "Removing prior config directory: $CONFIG_DIR"
-        rm -rf "$CONFIG_DIR"
+        if [ -d "$CONFIG_DIR/webfonts" ]; then
+            echo "Removing prior webfonts config directory: $CONFIG_DIR/webfonts"
+            rm -rf "$CONFIG_DIR/webfonts"
+        fi
+        if [ -d "$CONFIG_DIR/temp" ]; then
+            echo "Removing prior temp directory: $CONFIG_DIR/temp"
+            rm -rf "$CONFIG_DIR/temp"
+        fi
+        if [ -f "$CONFIG_DIR/i18n.json" ]; then
+            echo "Removing prior config file: $CONFIG_DIR/i18n.json"
+            rm -f "$CONFIG_DIR/i18n.json"
+        fi
     fi
 done

--- a/macos/buildResources/preinstall
+++ b/macos/buildResources/preinstall
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+CONFIG_DIR="~/pankosmia/{APP_SHORT_NAME}"
+
+if [ -d "$CONFIG_DIR" ]; then
+    echo "Removing prior config directory: $CONFIG_DIR"
+    rm -rf "$CONFIG_DIR"
+fi

--- a/macos/buildResources/preinstall
+++ b/macos/buildResources/preinstall
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -e
 
-CONFIG_DIR="~/pankosmia/{APP_SHORT_NAME}"
-
-if [ -d "$CONFIG_DIR" ]; then
-    echo "Removing prior config directory: $CONFIG_DIR"
-    rm -rf "$CONFIG_DIR"
-fi
+# Iterate over user home directories
+for USER_HOME in /Users/*; do
+    CONFIG_DIR="$USER_HOME/pankosmia/{APP_SHORT_NAME}"
+    if [ -d "$CONFIG_DIR" ]; then
+        echo "Removing prior config directory: $CONFIG_DIR"
+        rm -rf "$CONFIG_DIR"
+    fi
+done

--- a/macos/install/makeAllInstalls.sh
+++ b/macos/install/makeAllInstalls.sh
@@ -3,9 +3,11 @@
 # This script uses the APP_NAME environment variables as defined in app_config.env
 source ../../app_config.env
 
+EMSG="environment variable is not set in makeAllInstalls.sh."
+
 # Confirm the APP_NAME environment variables is set
 if [ -z "$APP_NAME" ]; then
-    echo "Error: APP_NAME environment variable is not set."
+    echo "Error: APP_NAME $EMSG"
     exit 1
 fi
 

--- a/macos/install/makeAllInstallsElectronite.sh
+++ b/macos/install/makeAllInstallsElectronite.sh
@@ -24,9 +24,17 @@ devRun="${1:-no}" # This is a development viewer run if $1 is -d
 # This script uses the APP_NAME environment variables as defined in app_config.env
 source ../../app_config.env
 
+EMSG="environment variable is not set in makeAllInstallsElecrtronite.sh."
+
 # Confirm the APP_NAME environment variables is set
 if [ -z "$APP_NAME" ]; then
-    echo "Error: APP_NAME environment variable is not set."
+    echo "Error: APP_NAME $EMSG"
+    exit 1
+fi
+
+# Confirm the APP_SHORT_NAME environment variables is set
+if [ -z "$APP_SHORT_NAME" ]; then
+    echo "Error: APP_SHORT_NAME $EMSG"
     exit 1
 fi
 
@@ -42,6 +50,8 @@ echo "APP_NAME=$APP_NAME"
 export APP_NAME="$APP_NAME"
 echo "APP_VERSION=$APP_VERSION"
 export APP_VERSION="$APP_VERSION"
+echo "APP_SHORT_NAME=$APP_SHORT_NAME" 
+export APP_SHORT_NAME="$APP_SHORT_NAME"
 
 ElectronArm64="https://github.com/unfoldingWord/electronite/releases/download/v37.1.0-graphite/electronite-v37.1.0-graphite-darwin-arm64.zip"
 ElectronIntel64="https://github.com/unfoldingWord/electronite/releases/download/v37.1.0-graphite/electronite-v37.1.0-graphite-darwin-x64.zip"

--- a/macos/install/makeInstall.sh
+++ b/macos/install/makeInstall.sh
@@ -97,7 +97,8 @@ cp ../buildResources/post_install_script.sh ../project/scripts/postinstall
 chmod +x ../project/scripts/postinstall
 PREINST_FILE="../project/scripts/preinstall"
 cp ../buildResources/preinstall "$PREINST_FILE"
-sed -i.bak "s/\${APP_SHORT_NAME}/$APP_SHORT_NAME/g" "$PREINST_FILE"
+sed -i.bak "s/{APP_SHORT_NAME}/$APP_SHORT_NAME/g" "$PREINST_FILE"
+echo "Replaced {APP_SHORT_NAME} with \"$APP_SHORT_NAME\" in $PREINST_FILE"
 chmod +x "$PREINST_FILE"
 
 # build pkg

--- a/macos/install/makeInstall.sh
+++ b/macos/install/makeInstall.sh
@@ -6,7 +6,7 @@ source ../../app_config.env
 # requires shc - do `brew install shc`
 
 # Confirm both APP_VERSION and APP_NAME environment variables are set
-if [ \( -z "$APP_VERSION" \) -o \( -z "$APP_NAME" \) ]; then
+if [ \( -z "$APP_VERSION" \) -o \( -z "$APP_NAME" \) -o \( -z "$APP_SHORT_NAME" \) ]; then
 
     if [ -z "$APP_VERSION" ]; then
       echo "Error: APP_VERSION environment variable is not set."
@@ -14,6 +14,10 @@ if [ \( -z "$APP_VERSION" \) -o \( -z "$APP_NAME" \) ]; then
 
     if [ -z "$APP_NAME" ]; then
       echo "Error: APP_NAME environment variable is not set."
+    fi
+
+    if [ -z "$APP_SHORT_NAME" ]; then
+      echo "Error: APP_SHORT_NAME environment variable is not set."
     fi
 
     exit 1
@@ -88,8 +92,12 @@ chmod 755 ../project/payload/"$APP_NAME".app/Contents/bin/server.bin
 cp -R ./lib ../project/payload/"$APP_NAME".app/Contents/
 
 mkdir -p ../project/scripts
-cp ../build/post_install_script.sh ../project/scripts/postinstall
+cp ../buildResources/post_install_script.sh ../project/scripts/postinstall
 chmod +x ../project/scripts/postinstall
+PREINST_FILE="../project/scripts/preinstall"
+cp ../buildResources/preinstall "$PREINST_FILE"
+sed -i.bak "s/\${APP_SHORT_NAME}/$APP_SHORT_NAME/g" "$PREINST_FILE"
+chmod +x "$PREINST_FILE"
 
 # build pkg
 cd ..

--- a/macos/install/makeInstall.sh
+++ b/macos/install/makeInstall.sh
@@ -6,18 +6,19 @@ source ../../app_config.env
 # requires shc - do `brew install shc`
 
 # Confirm both APP_VERSION and APP_NAME environment variables are set
+EMSG="environment variable is not set in makeInstall.sh."
 if [ \( -z "$APP_VERSION" \) -o \( -z "$APP_NAME" \) -o \( -z "$APP_SHORT_NAME" \) ]; then
 
     if [ -z "$APP_VERSION" ]; then
-      echo "Error: APP_VERSION environment variable is not set."
+      echo "Error: APP_VERSION $EMSG"
     fi
 
     if [ -z "$APP_NAME" ]; then
-      echo "Error: APP_NAME environment variable is not set."
+      echo "Error: APP_NAME $EMSG"
     fi
 
     if [ -z "$APP_SHORT_NAME" ]; then
-      echo "Error: APP_SHORT_NAME environment variable is not set."
+      echo "Error: APP_SHORT_NAME $EMSG"
     fi
 
     exit 1

--- a/macos/install/makeInstallElectronite.sh
+++ b/macos/install/makeInstallElectronite.sh
@@ -44,6 +44,12 @@ if [ -z "$APP_VERSION" ]; then
     exit 1
 fi
 
+# Check if APP_SHORT_NAME environment variable is set
+if [ -z "$APP_SHORT_NAME" ]; then
+    echo "Error: APP_SHORT_NAME environment variable is not set."
+    exit 1
+fi
+
 # Check if FILE_APP_NAME environment variable is set
 if [ -z "$FILE_APP_NAME" ]; then
     echo "Error: FILE_APP_NAME environment variable is not set."
@@ -180,8 +186,12 @@ if ! [[ $devRun =~ ^(-d) ]]; then
   echo "copied lib to $APP_BASE_DIR/Contents/"
 
   mkdir -p ../$pkgDir/project/scripts
-  cp ../install/post_install_script.sh ../$pkgDir/project/scripts/postinstall
+  cp ../buildResources/post_install_script.sh ../$pkgDir/project/scripts/postinstall
   chmod +x ../$pkgDir/project/scripts/postinstall
+  PREINST_FILE="../project/scripts/preinstall"
+  cp ../buildResources/preinstall "$PREINST_FILE"
+  sed -i.bak "s/\${APP_SHORT_NAME}/$APP_SHORT_NAME/g" "$PREINST_FILE"
+  chmod +x "$PREINST_FILE"
 fi
 
 # set execute permission on all folders

--- a/macos/install/makeInstallElectronite.sh
+++ b/macos/install/makeInstallElectronite.sh
@@ -192,7 +192,7 @@ if ! [[ $devRun =~ ^(-d) ]]; then
   PREINST_FILE="../$pkgDir/project/scripts/preinstall"
   cp ../buildResources/preinstall "$PREINST_FILE"
   echo "copied preinstall to $SCRIPTS_DIR"
-  sed -i.bak "s/\${APP_SHORT_NAME}/$APP_SHORT_NAME/g" "$PREINST_FILE"
+  sed -i.bak "s/{APP_SHORT_NAME}/$APP_SHORT_NAME/g" "$PREINST_FILE"
   echo "Replaced {APP_SHORT_NAME} with \"$APP_SHORT_NAME\" in $PREINST_FILE."
   chmod +x "$PREINST_FILE"
   POSTINST_FILE="../$pkgDir/project/scripts/postinstall"

--- a/macos/install/makeInstallElectronite.sh
+++ b/macos/install/makeInstallElectronite.sh
@@ -32,27 +32,29 @@
 # Output:
 #   Creates installer package at: ../releases/macos/<app-name>_installer_<arch>_<version>.pkg
 
+EMSG="environment variable is not set in makeInstallElectronite.sh."
+
 # Check if APP_NAME environment variable is set
 if [ -z "$APP_NAME" ]; then
-    echo "Error: APP_NAME environment variable is not set."
+    echo "Error: APP_NAME $EMSG"
     exit 1
 fi
 
 # Check if APP_VERSION environment variable is set
 if [ -z "$APP_VERSION" ]; then
-    echo "Error: APP_VERSION environment variable is not set."
+    echo "Error: APP_VERSION $EMSG"
     exit 1
 fi
 
 # Check if APP_SHORT_NAME environment variable is set
 if [ -z "$APP_SHORT_NAME" ]; then
-    echo "Error: APP_SHORT_NAME environment variable is not set."
+    echo "Error: APP_SHORT_NAME $EMSG"
     exit 1
 fi
 
 # Check if FILE_APP_NAME environment variable is set
 if [ -z "$FILE_APP_NAME" ]; then
-    echo "Error: FILE_APP_NAME environment variable is not set."
+    echo "Error: FILE_APP_NAME $EMSG"
     exit 1
 fi
 
@@ -185,13 +187,19 @@ if ! [[ $devRun =~ ^(-d) ]]; then
   cp -R ./lib ${APP_BASE_DIR}/Contents/
   echo "copied lib to $APP_BASE_DIR/Contents/"
 
-  mkdir -p ../$pkgDir/project/scripts
-  cp ../buildResources/post_install_script.sh ../$pkgDir/project/scripts/postinstall
-  chmod +x ../$pkgDir/project/scripts/postinstall
-  PREINST_FILE="../project/scripts/preinstall"
+  SCRIPTS_DIR="../$pkgDir/project/scripts"
+  mkdir -p $SCRIPTS_DIR
+  PREINST_FILE="../$pkgDir/project/scripts/preinstall"
   cp ../buildResources/preinstall "$PREINST_FILE"
+  echo "copied preinstall to $SCRIPTS_DIR"
   sed -i.bak "s/\${APP_SHORT_NAME}/$APP_SHORT_NAME/g" "$PREINST_FILE"
+  echo "Replaced {APP_SHORT_NAME} with \"$APP_SHORT_NAME\" in $PREINST_FILE."
   chmod +x "$PREINST_FILE"
+  POSTINST_FILE="../$pkgDir/project/scripts/postinstall"
+  cp ../build/post_install_script.sh $POSTINST_FILE
+  echo "copied post_install_script.sh to $SCRIPTS_DIR"
+  echo "Variables in post_install_script.sh were already replaced by: node build.js"
+  chmod +x $POSTINST_FILE
 fi
 
 # set execute permission on all folders

--- a/macos/install/makeInstallFromBuild.sh
+++ b/macos/install/makeInstallFromBuild.sh
@@ -3,15 +3,17 @@
 # This script uses the APP_VERSION and APP_NAME environment variables as defined in app_config.env, as well as $filename
 source ../../app_config.env $filename
 
+EMSG="environment variable is not set in makeInstallFromBuild.sh."
+
 # Confirm both APP_VERSION and APP_NAME environment variables are set
 if [ \( -z "$APP_VERSION" \) -o \( -z "$APP_NAME" \) ]; then
 
     if [ -z "$APP_VERSION" ]; then
-      echo "Error: APP_VERSION environment variable is not set."
+      echo "Error: APP_VERSION $EMSG"
     fi
 
     if [ -z "$APP_NAME" ]; then
-      echo "Error: APP_NAME environment variable is not set."
+      echo "Error: APP_NAME $EMSG"
     fi
 
     exit 1

--- a/windows/install/makeAllInstallsElectronite.ps1
+++ b/windows/install/makeAllInstallsElectronite.ps1
@@ -40,6 +40,7 @@ get-content ..\..\app_config.env | foreach {
 
 $env:APP_NAME=$APP_NAME.Trim("'")
 $env:APP_VERSION=$APP_VERSION
+$env:APP_SHORT_NAME=$APP_SHORT_NAME
 
 if ($IsGHA -ne 'N') {
   # show environment variables defined

--- a/windows/install/makeInstall.iss
+++ b/windows/install/makeInstall.iss
@@ -9,6 +9,12 @@ OutputBaseFilename={#GetEnv('FILE_APP_NAME')}-windows-setup-{#GetEnv('APP_VERSIO
 Compression=lzma
 SolidCompression=yes
 
+[Tasks]
+Name: "desktopicon"; Description: "Create a {#GetEnv('APP_NAME')} &desktop icon"; GroupDescription: "{#GetEnv('APP_NAME')} icons:"
+
+[InstallDelete]
+Type: filesandordirs; Name: "~\pankosmia\{#GetEnv('APP_SHORT_NAME')}"
+
 [Files]
 Source: "..\build\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 Source: "..\buildResources\appLauncher.bat"; DestDir: "{app}"; Flags: ignoreversion
@@ -23,6 +29,3 @@ Name: "{group}\Uninstall {#GetEnv('APP_NAME')} (Delete App Files)"; Filename: "{
 
 [Run]
 Filename: "{app}\custom_uninstaller.bat"; Parameters: "{app}"
-
-[Tasks]
-Name: "desktopicon"; Description: "Create a {#GetEnv('APP_NAME')} &desktop icon"; GroupDescription: "{#GetEnv('APP_NAME')} icons:"

--- a/windows/install/makeInstall.iss
+++ b/windows/install/makeInstall.iss
@@ -13,7 +13,9 @@ SolidCompression=yes
 Name: "desktopicon"; Description: "Create a {#GetEnv('APP_NAME')} &desktop icon"; GroupDescription: "{#GetEnv('APP_NAME')} icons:"
 
 [InstallDelete]
-Type: filesandordirs; Name: "{%USERPROFILE}\pankosmia\{#GetEnv('APP_SHORT_NAME')}"
+Type: filesandordirs; Name: "{%USERPROFILE}\pankosmia\{#GetEnv('APP_SHORT_NAME')}\webfonts"
+Type: filesandordirs; Name: "{%USERPROFILE}\pankosmia\{#GetEnv('APP_SHORT_NAME')}\temp"
+Type: files; Name: "{%USERPROFILE}\pankosmia\{#GetEnv('APP_SHORT_NAME')}\i18n.json"
 
 [Files]
 Source: "..\build\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs

--- a/windows/install/makeInstall.iss
+++ b/windows/install/makeInstall.iss
@@ -13,7 +13,7 @@ SolidCompression=yes
 Name: "desktopicon"; Description: "Create a {#GetEnv('APP_NAME')} &desktop icon"; GroupDescription: "{#GetEnv('APP_NAME')} icons:"
 
 [InstallDelete]
-Type: filesandordirs; Name: "~\pankosmia\{#GetEnv('APP_SHORT_NAME')}"
+Type: filesandordirs; Name: "{%USERPROFILE}\pankosmia\{#GetEnv('APP_SHORT_NAME')}"
 
 [Files]
 Source: "..\build\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs

--- a/windows/install/makeInstallElectronite.iss
+++ b/windows/install/makeInstallElectronite.iss
@@ -9,6 +9,12 @@ OutputBaseFilename={#GetEnv('FILE_APP_NAME')}-windows-setup-standalone-{#GetEnv(
 Compression=lzma
 SolidCompression=yes
 
+[Tasks]
+Name: "desktopicon"; Description: "Create a {#GetEnv('APP_NAME')} &desktop icon"; GroupDescription: "{#GetEnv('APP_NAME')} icons:"
+
+[InstallDelete]
+Type: filesandordirs; Name: "~\pankosmia\{#GetEnv('APP_SHORT_NAME')}"
+
 [Files]
 Source: "..\temp\project\payload\app\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 Source: "..\..\globalBuildResources\{#AppIcoName}"; DestDir: "{app}"
@@ -21,6 +27,3 @@ Name: "{group}\Uninstall {#GetEnv('APP_NAME')} (Delete App Files)"; Filename: "{
 
 [Run]
 Filename: "{app}\custom_uninstaller.bat"; Parameters: "{app}"
-
-[Tasks]
-Name: "desktopicon"; Description: "Create a {#GetEnv('APP_NAME')} &desktop icon"; GroupDescription: "{#GetEnv('APP_NAME')} icons:"

--- a/windows/install/makeInstallElectronite.iss
+++ b/windows/install/makeInstallElectronite.iss
@@ -16,7 +16,9 @@ SolidCompression=yes
 Name: "desktopicon"; Description: "Create a {#GetEnv('APP_NAME')} &desktop icon"; GroupDescription: "{#GetEnv('APP_NAME')} icons:"
 
 [InstallDelete]
-Type: filesandordirs; Name: "{%USERPROFILE}\pankosmia\{#GetEnv('APP_SHORT_NAME')}"
+Type: filesandordirs; Name: "{%USERPROFILE}\pankosmia\{#GetEnv('APP_SHORT_NAME')}\webfonts"
+Type: filesandordirs; Name: "{%USERPROFILE}\pankosmia\{#GetEnv('APP_SHORT_NAME')}\temp"
+Type: files; Name: "{%USERPROFILE}\pankosmia\{#GetEnv('APP_SHORT_NAME')}\i18n.json"
 
 [Files]
 Source: "..\temp\project\payload\app\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs

--- a/windows/install/makeInstallElectronite.iss
+++ b/windows/install/makeInstallElectronite.iss
@@ -1,3 +1,6 @@
+#define AppShortName GetEnv("APP_SHORT_NAME")
+#pragma message "APP_SHORT_NAME resolved to: " + AppShortName
+
 #define AppIcoName "icon.ico"
 
 [Setup]
@@ -13,7 +16,7 @@ SolidCompression=yes
 Name: "desktopicon"; Description: "Create a {#GetEnv('APP_NAME')} &desktop icon"; GroupDescription: "{#GetEnv('APP_NAME')} icons:"
 
 [InstallDelete]
-Type: filesandordirs; Name: "~\pankosmia\{#GetEnv('APP_SHORT_NAME')}"
+Type: filesandordirs; Name: "{%USERPROFILE}\pankosmia\{#GetEnv('APP_SHORT_NAME')}"
 
 [Files]
 Source: "..\temp\project\payload\app\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs

--- a/windows/install/makeInstallElectronite.ps1
+++ b/windows/install/makeInstallElectronite.ps1
@@ -64,6 +64,13 @@ try {
         echo "FILE_APP_NAME=$env:FILE_APP_NAME"
     }
 
+    # Check if APP_SHORT_NAME environment variable is set
+    if (-not $env:APP_SHORT_NAME) {
+        Write-Host "Error: APP_SHORT_NAME environment variable is not set."
+        Write-Host "Set it in app_config.env"
+        exit 1
+    }
+
     Write-Host "Version is $env:APP_VERSION"
 
     # Needed for local bundles. Not required in GHA but does no harm.

--- a/windows/install/makeInstallElectronite.ps1
+++ b/windows/install/makeInstallElectronite.ps1
@@ -41,24 +41,26 @@ param(
 # Save the initial working directory
 $initialLocation = Get-Location
 
+$eMsg = "environment variable is not set in makeInstallElectronite.ps1."
+
 try {
     # Check if APP_VERSION environment variable is set
     if (-not $env:APP_VERSION) {
-        Write-Host "Error: APP_VERSION environment variable is not set."
+        Write-Host "Error: APP_VERSION $eMsg"
         Write-Host "Set it in app_config.env"
         exit 1
     }
     
     # Check if APP_NAME environment variable is set
     if (-not $env:APP_NAME) {
-        Write-Host "Error: APP_NAME environment variable is not set."
+        Write-Host "Error: APP_NAME $eMsg"
         Write-Host "Set it in app_config.env"
         exit 1
     }
     
     # Check if FILE_APP_NAME environment variable is set
     if (-not $env:FILE_APP_NAME) {
-        Write-Host "Warning: FILE_APP_NAME environment variable is not set. Generating..."
+        Write-Host "FILE_APP_NAME $eMsg. Generating..."
         $fileAppName = $env:APP_NAME.ToLower().Replace(" ","-").Replace("'","")   # Use lower case app name in filename and replace spaces with dashes (-) and remove single apostrophes (')
         $env:FILE_APP_NAME = $fileAppName
         echo "FILE_APP_NAME=$env:FILE_APP_NAME"
@@ -66,7 +68,7 @@ try {
 
     # Check if APP_SHORT_NAME environment variable is set
     if (-not $env:APP_SHORT_NAME) {
-        Write-Host "Error: APP_SHORT_NAME environment variable is not set."
+        Write-Host "Error: APP_SHORT_NAME $eMsg"
         Write-Host "Set it in app_config.env"
         exit 1
     }


### PR DESCRIPTION
### What
For the app being installed, this PR _removes_ the old i18n.json, webfonts dir, and temp dir.  It does _not_ remove anything else, which right now is `user_settings.json`, `app_state.json` and the blobs dir.

### How
- Windows: It's a simple Inno Setup `.iss` entry, which reads env vars. Yay!
- Linux: It's setup as a `preinst` bash script. This uses `sed` to replace the short name in the script after it is copied where it is needed, in DEBIAN root, before the installer is built with dpkg-deb.
- MacOS: It's setup as a `preinstall` bash script because macos installer runs it with /bin/sh, even though its default interactive shell is zsh. This uses `sed` to replace the short name in the script after it is copied where it is needed, which is in a script dir that is then specified as an argument when the installer is built with pkgbuild.