### PR TITLE
Set i18nPatch.json free!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ macos/buildResources/setup/app_setup.json
 linux/buildResources/setup/app_setup.json
 buildSpec.json
 buildSpec.bak
-globalBuildResources/i18nPatch.json
 globalBuildResources/product.json
 branding/building_blocks_/for_favicon_ico/favicon.ico
 branding/building_blocks_/for_icon_ico/icon.ico

--- a/globalBuildResources/i18nPatch.json
+++ b/globalBuildResources/i18nPatch.json
@@ -1,0 +1,9 @@
+{
+  "branding": {
+    "software": {
+      "name": {
+        "en": "Pankosmia Desktop App Template"
+      }
+    }
+  }
+}

--- a/linux/scripts/app_setup.bsh
+++ b/linux/scripts/app_setup.bsh
@@ -8,8 +8,12 @@ echo "     *   - /windows/buildResources/setup/app_setup.json *"
 echo "     *   - /macos/buildResources/setup/app_setup.json   *"
 echo "     *   - /linux/buildResources/setup/app_setup.json   *"
 echo "     *   - /buildSpec.json                              *"
-echo "     *   - /globalBuildResources/i18nPatch.json         *"
 echo "     *   - /globalBuildResources/product.json           *"
+echo "     *                                                  *"
+echo "     * /globalBuildResources/i18nPatch.json:            *"
+echo "     *   - Created if it does not exist, otherwise      *"
+echo "     *     the English name (branding/software/name/en) *"
+echo "     *     is ensured as set to APP_NAME.               *"
 echo "     ****************************************************"
 echo
 
@@ -20,15 +24,32 @@ spec="../../buildSpec.json"
 name="../../globalBuildResources/i18nPatch.json"
 product="../../globalBuildResources/product.json"
 
-echo "{"> $name
-echo "  \"branding\": {">> $name
-echo "    \"software\": {">> $name
-echo "      \"name\": {">> $name
-echo "        \"en\": \"$APP_NAME\"">> $name
-echo "      }">> $name
-echo "    }">> $name
-echo "  }">> $name
-echo "}">> $name
+if [ ! -f "$name" ]; then
+  # File doesn't exist — build it from scratch
+  echo "{"> $name
+  echo "  \"branding\": {">> $name
+  echo "    \"software\": {">> $name
+  echo "      \"name\": {">> $name
+  echo "        \"en\": \"$APP_NAME\"">> $name
+  echo "      }">> $name
+  echo "    }">> $name
+  echo "  }">> $name
+  echo "}">> $name
+else
+  # File exists — update only branding.software.name.en,
+  # restoring the key path if any part of it is missing
+  node -e "
+    const fs = require('fs');
+    const data = JSON.parse(fs.readFileSync('$name', 'utf8'));
+
+    if (!data.branding) data.branding = {};
+    if (!data.branding.software) data.branding.software = {};
+    if (!data.branding.software.name) data.branding.software.name = {};
+    data.branding.software.name.en = '$APP_NAME';
+
+    fs.writeFileSync('$name', JSON.stringify(data, null, 2) + '\n');
+  "
+fi
 
 echo "{"> $spec
 echo "  \"app\": {">> $spec

--- a/linux/scripts/sync.bsh
+++ b/linux/scripts/sync.bsh
@@ -19,6 +19,7 @@ doSync() {
     "globalBuildResources/favicon@1.5x.png"
     "globalBuildResources/favicon@1.75x.png"
     "globalBuildResources/favicon@2x.png"
+    "globalBuildResources/i18nPatch.json"
     "globalBuildResources/theme.json"
     "branding/building_blocks/for_favicon_ico/favicon_16x16.png"
     "branding/building_blocks/for_favicon_ico/favicon_32x32.png"

--- a/macos/scripts/app_setup.zsh
+++ b/macos/scripts/app_setup.zsh
@@ -8,8 +8,12 @@ echo "     *   - /windows/buildResources/setup/app_setup.json *"
 echo "     *   - /macos/buildResources/setup/app_setup.json   *"
 echo "     *   - /linux/buildResources/setup/app_setup.json   *"
 echo "     *   - /buildSpec.json                              *"
-echo "     *   - /globalBuildResources/i18nPatch.json         *"
 echo "     *   - /globalBuildResources/product.json           *"
+echo "     *                                                  *"
+echo "     * /globalBuildResources/i18nPatch.json:            *"
+echo "     *   - Created if it does not exist, otherwise      *"
+echo "     *     the English name (branding/software/name/en) *"
+echo "     *     is ensured as set to APP_NAME.               *"
 echo "     ****************************************************"
 echo
 
@@ -20,15 +24,32 @@ spec="../../buildSpec.json"
 name="../../globalBuildResources/i18nPatch.json"
 product="../../globalBuildResources/product.json"
 
-echo "{"> $name
-echo "  \"branding\": {">> $name
-echo "    \"software\": {">> $name
-echo "      \"name\": {">> $name
-echo "        \"en\": \"$APP_NAME\"">> $name
-echo "      }">> $name
-echo "    }">> $name
-echo "  }">> $name
-echo "}">> $name
+if [ ! -f "$name" ]; then
+  # File doesn't exist — build it from scratch
+  echo "{"> $name
+  echo "  \"branding\": {">> $name
+  echo "    \"software\": {">> $name
+  echo "      \"name\": {">> $name
+  echo "        \"en\": \"$APP_NAME\"">> $name
+  echo "      }">> $name
+  echo "    }">> $name
+  echo "  }">> $name
+  echo "}">> $name
+else
+  # File exists — update only branding.software.name.en,
+  # restoring the key path if any part of it is missing
+  node -e "
+    const fs = require('fs');
+    const data = JSON.parse(fs.readFileSync('$name', 'utf8'));
+
+    if (!data.branding) data.branding = {};
+    if (!data.branding.software) data.branding.software = {};
+    if (!data.branding.software.name) data.branding.software.name = {};
+    data.branding.software.name.en = '$APP_NAME';
+
+    fs.writeFileSync('$name', JSON.stringify(data, null, 2) + '\n');
+  "
+fi
 
 echo "{"> $spec
 echo "  \"app\": {">> $spec

--- a/macos/scripts/sync.zsh
+++ b/macos/scripts/sync.zsh
@@ -19,6 +19,7 @@ doSync() {
     "globalBuildResources/favicon@1.5x.png"
     "globalBuildResources/favicon@1.75x.png"
     "globalBuildResources/favicon@2x.png"
+    "globalBuildResources/i18nPatch.json"
     "globalBuildResources/theme.json"
     "branding/building_blocks/for_favicon_ico/favicon_16x16.png"
     "branding/building_blocks/for_favicon_ico/favicon_32x32.png"

--- a/windows/scripts/app_setup.bat
+++ b/windows/scripts/app_setup.bat
@@ -8,8 +8,12 @@ echo      *   - \windows\buildResources\setup\app_setup.json *
 echo      *   - \macos\buildResources\setup\app_setup.json   *
 echo      *   - \linux\buildResources\setup\app_setup.json   *
 echo      *   - \buildSpec.json                              *
-echo      *   - \globalBuildResources\i18nPatch.json         *
 echo      *   - \globalBuildResources\product.json           *
+echo      *                                                  *
+echo      * \globalBuildResources\i18nPatch.json:            *
+echo      *   - Created if it does not exist, otherwise      *
+echo      *     the English name (branding/software/name/en) *
+echo      *     is ensured as set to APP_NAME.               *
 echo      ****************************************************
 echo.
 
@@ -22,15 +26,24 @@ set "spec=..\..\buildSpec.json"
 set "name=..\..\globalBuildResources\i18nPatch.json"
 set "product=..\..\globalBuildResources\product.json"
 
-echo {> %name%
-echo   "branding": {>> %name%
-echo     "software": {>> %name%
-echo       "name": {>> %name%
-echo         "en": "%APP_NAME:'=%">> %name%
-echo       }>> %name%
-echo     }>> %name%
-echo   }>> %name%
-echo }>> %name%
+set "nameFwd=%name:\=/%"
+if not exist %name% (
+  echo {> %name%
+  echo   "branding": {>> %name%
+  echo     "software": {>> %name%
+  echo       "name": {>> %name%
+  echo         "en": "%APP_NAME:'=%">> %name%
+  echo       }>> %name%
+  echo     }>> %name%
+  echo   }>> %name%
+  echo }>> %name%
+) else (
+  REM File exists — update only branding.software.name.en,
+  REM restoring the key path if any part of it is missing; Keep `node -e` on a single line for cmd.exe!
+  setlocal DISABLEDELAYEDEXPANSION
+  node -e "const fs = require('fs'); const p = process.argv[1]; const data = JSON.parse(fs.readFileSync(p, 'utf8')); if (!data.branding) data.branding = {}; if (!data.branding.software) data.branding.software = {}; if (!data.branding.software.name) data.branding.software.name = {}; data.branding.software.name.en = process.argv[2]; fs.writeFileSync(p, JSON.stringify(data, null, 2) + '\n');" "%nameFwd%" "%APP_NAME:'=%"
+  endlocal
+)
 
 echo {> %spec%
 echo   "app": {>> %spec%

--- a/windows/scripts/sync.bat
+++ b/windows/scripts/sync.bat
@@ -118,6 +118,7 @@ REM --- Write protected files list to a temp file (avoids @ parsing issues) ---
   echo globalBuildResources\favicon@1.5x.png
   echo globalBuildResources\favicon@1.75x.png
   echo globalBuildResources\favicon@2x.png
+  echo globalBuildResources\i18nPatch.json
   echo globalBuildResources\theme.json
   echo branding\building_blocks\for_favicon_ico\favicon_16x16.png
   echo branding\building_blocks\for_favicon_ico\favicon_32x32.png


### PR DESCRIPTION
### This PR does the following:

`app_setup.[bsh|bat|zsh]`:
- If i18nPatch.json does not exist, it writes it like it like it has been doing, as it is required.
- If i18nPatch.json already exists:
  - If `branding/software/name/en` does not exist, then it will be created, as it is required.
  - If `branding/software/name/en` already exists, then it ensures it is set to APP_NAME as defined in `app_config.env`
 
`i18nPatch.json`:
- Is now part of the repo
- Is protected from being synced by the `sync` script.
  
### Testing notes:
- tested on MacOS, Windows, and Ubuntu)
  - with no i18nPatch.json
  - with a `branding/software/name/en` different from APP_NAME as defined in `app_config.env` (gets corrected)
  - with a missing name key (gets added)
  - with a missing en key (gets added)
  
### How?
-  Via `node -e` (`--eval`), back to where you started things off -- imagine that! ;-)
- FYI, in Windows, cmd does not support multiline `node -e`, so it all on one line, which is fine.