### PR TITLE
Update GHA Node Ver

### DIFF
--- a/.github/workflows/linux-build-steps.yml
+++ b/.github/workflows/linux-build-steps.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.11.0'
+          node-version: '20.19.5'
 
       # Install the repository
       - name: Install this repo

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.11.0'
+          node-version: '20.19.5'
 
       # Install the repository
       - name: Install this repo

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.11.0'
+          node-version: '20.19.5'
 
       # Set APP_VERSION from app_config.env
       - name: Extract APP_VERSION from app_config.env

--- a/app_config.env
+++ b/app_config.env
@@ -25,6 +25,7 @@ CLIENT8=core-contenthandler_obs
 CLIENT9=core-contenthandler_bcv
 CLIENT10=core-contenthandler_version_manager
 CLIENT11=core-contenthandler-generic
+CLIENT12=core-contenthandler_t_core
 
 # Theme -- Customize /globalBuildResources/favicon.ico and /globalBuildResources/theme.json directly.
 


### PR DESCRIPTION
This fixes the following WIndows and MacOS npm errors under node v20.11.0 on `core-client-dashboard` and `core-contenthandler_t_core`.:

> `Error: Cannot find module @rollup/rollup-win32-x64-msvc. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try npm i again after removing both package-lock.json and node_modules directory. `