### PR TITLE
Bump server

### DIFF
--- a/local_server.env
+++ b/local_server.env
@@ -1,3 +1,3 @@
-dev=0.14.12
+dev=0.16.1
 qa=0.14.12
 # main will use the version number in `local_server\Cargo.toml`

--- a/local_server/Cargo.toml
+++ b/local_server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-pankosmia_web = "=0.16.1"
+pankosmia_web = "=0.14.12"
 rocket = { version = "0.5.1", features = ["json"] }
 serde_json = "1.0.132"
 tokio = "1.43.0"

--- a/local_server/Cargo.toml
+++ b/local_server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-pankosmia_web = "=0.14.12"
+pankosmia_web = "=0.16.1"
 rocket = { version = "0.5.1", features = ["json"] }
 serde_json = "1.0.132"
 tokio = "1.43.0"


### PR DESCRIPTION
This is required for all the new dev clients since all the non-client endpoints have moved under /api. (We'll want to get this to main quite quickly.)