### PR TITLE
rename url's organisation in lowercase

### DIFF
--- a/globalBuildResources/product_resources/core-client-remote-repos/organizations/organization.json
+++ b/globalBuildResources/product_resources/core-client-remote-repos/organizations/organization.json
@@ -2,15 +2,15 @@
   "organizations": [
     {
       "name": "BurritoTruck",
-      "url": "git.door43.org/BurritoTruck"
+      "url": "git.door43.org/burritotruck"
     },
     {
       "name": "unfoldingWord (SB resources)",
-      "url": "git.door43.org/uW"
+      "url": "git.door43.org/uw"
     },
       {
       "name": "unfoldingWord",
-      "url": "git.door43.org/unfoldingWord"
+      "url": "git.door43.org/unfoldingword"
     },
     {
         "name":"Aquifer",


### PR DESCRIPTION
I’ve put the organisation names in lower case in the URL because, when searching for resources via organisations, I create files in lower case, which results in duplicate organisation files in the local repository

<img width="421" height="123" alt="image" src="https://github.com/user-attachments/assets/1c66cfa0-3fdd-4bb1-93fd-eaf3c86d7885" />

To avoid the problem from the outset, the file will be created in lower case