### PR TITLE
Run+ga/add pdf gen

### DIFF
--- a/buildResources/electron/electronDevStartup.js
+++ b/buildResources/electron/electronDevStartup.js
@@ -33,7 +33,7 @@ const { pipeline } = require('stream/promises');
 
 const FIREFOX_VERSION = '149.0.2';
 const FIREFOX_BUILD_ID = 'stable_' + FIREFOX_VERSION;
-const BROWSER_CACHE_DIR = path.join(app.getPath('userData'), 'browsers');
+const BROWSER_CACHE_DIR = path.join(app.getPath('home'), 'pankosmia', '_assets');
 
 // Where the extracted Firefox binary lives on Windows
 const FIREFOX_WIN_EXTRACT_DIR = path.join(BROWSER_CACHE_DIR, 'firefox', 'win64-' + FIREFOX_BUILD_ID);

--- a/buildResources/electron/electronDevStartup.js
+++ b/buildResources/electron/electronDevStartup.js
@@ -417,35 +417,41 @@ app.whenReady().then(() => {
       throw new Error('Firefox browser engine is not installed. Please download it first.');
     }
 
+    const result = await dialog.showSaveDialog();
+    if (result.canceled) return null;
+
     const browser = await puppeteer.launch({
       headless: true,
       browser: "firefox",
       executablePath: getFirefoxExecutablePath(),
     });
-    const result = await dialog.showSaveDialog();
 
-    const page = await browser.newPage();
-    const response = await fetch(
-      `http://127.0.0.1:${env.ROCKET_PORT}/temp/bytes/${uuid}`,
-      {
-        method: "GET",
-      },
-    );
+    try {
+      const page = await browser.newPage();
+      const response = await fetch(
+        `http://127.0.0.1:${env.ROCKET_PORT}/temp/bytes/${uuid}`,
+        {
+          method: "GET",
+        },
+      );
 
-    const resultHTML = await response.text();
-    await page.setContent(resultHTML, {
-      waitUntil: "networkidle0",
-    });
+      const resultHTML = await response.text();
+      await page.setContent(resultHTML, {
+        waitUntil: "networkidle0",
+      });
 
-    await page.evaluate(() => document.fonts.ready);
+      await page.evaluate(() => document.fonts.ready);
 
-    await page.pdf({
-      path: result.filePath,
-      format: "A3",
-      printBackground: true,
-    });
+      await page.pdf({
+        path: result.filePath,
+        format: "A3",
+        printBackground: true,
+      });
 
-    await browser.close();
+      return result.filePath;
+    } finally {
+      await browser.close();
+    }
 
     return result.filePath;
   });

--- a/buildResources/electron/electronDevStartup.js
+++ b/buildResources/electron/electronDevStartup.js
@@ -21,39 +21,62 @@
  * - Environment variable APP_NAME must be set for proper application naming
  */
 
-const { app, BrowserWindow, Menu, shell, ipcMain, ipcRenderer, contextBridge, dialog } = require('electron');
-const { spawn, execSync } = require('child_process');
-const path = require('path');
-const net = require('net');
-const fs = require('fs');
-const puppeteer = require('puppeteer-core');
-const os = require('os');
-const { install, computeExecutablePath } = require('@puppeteer/browsers');
-const { pipeline } = require('stream/promises');
+const {
+  app,
+  BrowserWindow,
+  Menu,
+  shell,
+  ipcMain,
+  ipcRenderer,
+  contextBridge,
+  dialog,
+} = require("electron");
+const { spawn, execSync } = require("child_process");
+const path = require("path");
+const net = require("net");
+const fs = require("fs");
+const puppeteer = require("puppeteer-core");
+const os = require("os");
+const { install, computeExecutablePath } = require("@puppeteer/browsers");
+const { pipeline } = require("stream/promises");
 
-const FIREFOX_VERSION = '149.0.2';
-const FIREFOX_BUILD_ID = 'stable_' + FIREFOX_VERSION;
-const BROWSER_CACHE_DIR = path.join(app.getPath('home'), 'pankosmia', '_assets');
+const FIREFOX_VERSION = "149.0.2";
+const FIREFOX_BUILD_ID = "stable_" + FIREFOX_VERSION;
+const BROWSER_CACHE_DIR = path.join(
+  app.getPath("home"),
+  "pankosmia",
+  "_assets",
+);
 
 // Where the extracted Firefox binary lives on Windows
-const FIREFOX_WIN_EXTRACT_DIR = path.join(BROWSER_CACHE_DIR, 'firefox', 'win64-' + FIREFOX_BUILD_ID);
+const FIREFOX_WIN_EXTRACT_DIR = path.join(
+  BROWSER_CACHE_DIR,
+  "firefox",
+  "win64-" + FIREFOX_BUILD_ID,
+);
 
 const env = {
   ...process.env,
-  APP_RESOURCES_DIR: process.env.APP_RESOURCES_DIR === undefined ? './lib/' : process.env.APP_RESOURCES_DIR,
+  APP_RESOURCES_DIR:
+    process.env.APP_RESOURCES_DIR === undefined
+      ? "./lib/"
+      : process.env.APP_RESOURCES_DIR,
 };
 
 function findFreePort(start = 19119, end = 65535) {
   return new Promise((resolve, reject) => {
     let port = start;
     function tryPort() {
-      if (port > end) return reject(new Error('free port not found'));
+      if (port > end) return reject(new Error("free port not found"));
       const server = net.createServer();
-      server.once('error', () => { port++; tryPort(); });
-      server.once('listening', () => {
+      server.once("error", () => {
+        port++;
+        tryPort();
+      });
+      server.once("listening", () => {
         server.close(() => resolve(port));
       });
-      server.listen(port, '127.0.0.1');
+      server.listen(port, "127.0.0.1");
     }
     tryPort();
   });
@@ -61,29 +84,29 @@ function findFreePort(start = 19119, end = 65535) {
 
 // Use existing env var or find one
 async function getPort() {
-  if (env.ROCKET_PORT && env.ROCKET_PORT.trim() !== '') {
+  if (env.ROCKET_PORT && env.ROCKET_PORT.trim() !== "") {
     return Number(env.ROCKET_PORT);
   }
   return await findFreePort(19119);
 }
 
 getPort()
-  .then(port => {
-    console.log('Using port ', port);
+  .then((port) => {
+    console.log("Using port ", port);
     if (env.ROCKET_PORT === undefined) env.ROCKET_PORT = port;
   })
-  .catch(err => {
-    console.error('Failed to obtain port:', err);
+  .catch((err) => {
+    console.error("Failed to obtain port:", err);
     app.quit?.();
   });
 
-app.name = '${APP_NAME}';
+app.name = "${APP_NAME}";
 let canClose = true;
 
 // Helper to get the Firefox executable path (used by generate-pdf)
 function getFirefoxExecutablePath() {
   return computeExecutablePath({
-    browser: 'firefox',
+    browser: "firefox",
     buildId: FIREFOX_BUILD_ID,
     cacheDir: BROWSER_CACHE_DIR,
   });
@@ -105,22 +128,25 @@ function isFirefoxInstalled() {
  */
 async function downloadFirefoxWindows(event) {
   const url = `https://archive.mozilla.org/pub/firefox/releases/${FIREFOX_VERSION}/win64/en-US/Firefox%20Setup%20${FIREFOX_VERSION}.exe`;
-  const tempExe = path.join(os.tmpdir(), `firefox-setup-${FIREFOX_VERSION}.exe`);
+  const tempExe = path.join(
+    os.tmpdir(),
+    `firefox-setup-${FIREFOX_VERSION}.exe`,
+  );
   const extractDir = FIREFOX_WIN_EXTRACT_DIR;
 
-  console.log('Download URL:', url);
-  console.log('Temp file:', tempExe);
-  console.log('Extract to:', extractDir);
+  console.log("Download URL:", url);
+  console.log("Temp file:", tempExe);
+  console.log("Extract to:", extractDir);
 
   // Step 1: Download the .exe with progress
-  event.sender.send('download-progress', 0);
+  event.sender.send("download-progress", 0);
 
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`Download failed: HTTP ${response.status} from ${url}`);
   }
 
-  const totalBytes = parseInt(response.headers.get('content-length'), 10) || 0;
+  const totalBytes = parseInt(response.headers.get("content-length"), 10) || 0;
   let downloadedBytes = 0;
 
   // Ensure temp directory exists
@@ -136,167 +162,175 @@ async function downloadFirefoxWindows(event) {
     downloadedBytes += value.length;
     if (totalBytes > 0) {
       const percent = Math.round((downloadedBytes / totalBytes) * 100);
-      event.sender.send('download-progress', percent);
+      event.sender.send("download-progress", percent);
     }
   }
 
   fileStream.end();
   await new Promise((resolve, reject) => {
-    fileStream.on('finish', resolve);
-    fileStream.on('error', reject);
+    fileStream.on("finish", resolve);
+    fileStream.on("error", reject);
   });
 
-  console.log('Download complete, extracting...');
-  event.sender.send('download-progress', 100);
+  console.log("Download complete, extracting...");
+  event.sender.send("download-progress", 100);
 
-// Step 2: Extract the self-extracting 7z archive
-const _7z = require('7zip-min');
+  // Step 2: Extract the self-extracting 7z archive
+  const _7z = require("7zip-min");
 
-await new Promise((resolve, reject) => {
-  _7z.unpack(tempExe, extractDir, (err) => {
-    if (err) reject(new Error(`Firefox extraction failed: ${err.message}`));
-    else resolve();
+  await new Promise((resolve, reject) => {
+    _7z.unpack(tempExe, extractDir, (err) => {
+      if (err) reject(new Error(`Firefox extraction failed: ${err.message}`));
+      else resolve();
+    });
   });
-});
 
   // Step 3: Clean up temp file
   try {
     fs.unlinkSync(tempExe);
-    console.log('Temp file cleaned up');
+    console.log("Temp file cleaned up");
   } catch {
-    console.warn('Could not delete temp file:', tempExe);
+    console.warn("Could not delete temp file:", tempExe);
   }
 
   // Step 4: Verify extraction
   const exePath = getFirefoxExecutablePath();
   if (!fs.existsSync(exePath)) {
-    throw new Error(`Extraction appeared to succeed but firefox.exe not found at: ${exePath}`);
+    throw new Error(
+      `Extraction appeared to succeed but firefox.exe not found at: ${exePath}`,
+    );
   }
 
-  console.log('Firefox extracted successfully to:', exePath);
+  console.log("Firefox extracted successfully to:", exePath);
 }
 
 /**
  * Downloads Firefox on macOS/Linux using @puppeteer/browsers install().
  */
 async function downloadFirefoxDefault(event) {
-  event.sender.send('download-progress', null);
+  event.sender.send("download-progress", null);
 
   await install({
-    browser: 'firefox',
+    browser: "firefox",
     buildId: FIREFOX_BUILD_ID,
     cacheDir: BROWSER_CACHE_DIR,
     onProgress: (downloadedBytes, totalBytes) => {
       if (
-        typeof downloadedBytes === 'number' &&
-        typeof totalBytes === 'number' &&
+        typeof downloadedBytes === "number" &&
+        typeof totalBytes === "number" &&
         totalBytes > 0
       ) {
         const percent = Math.round((downloadedBytes / totalBytes) * 100);
-        event.sender.send('download-progress', percent);
+        event.sender.send("download-progress", percent);
       }
     },
   });
 }
 
 function InitializeMenu() {
-  const isMac = process.platform === 'darwin';
+  const isMac = process.platform === "darwin";
   const template = [
     {
-      label: 'Edit',
+      label: "Edit",
       submenu: [
-        {role: 'undo'},
-        {role: 'redo'},
-        {type: 'separator'},
-        {role: 'cut'},
-        {role: 'copy'},
-        {role: 'paste'},
-        {role: 'pasteAndMatchStyle'},
+        { role: "undo" },
+        { role: "redo" },
+        { type: "separator" },
+        { role: "cut" },
+        { role: "copy" },
+        { role: "paste" },
+        { role: "pasteAndMatchStyle" },
         // {role: 'delete'},
-        {role: 'selectAll'}
-      ]
+        { role: "selectAll" },
+      ],
     },
     {
-      label: 'View',
+      label: "View",
       submenu: [
         {
-          label: 'Default Zoom',
-          accelerator: isMac ? 'Cmd+0' : 'Ctrl+0',
+          label: "Default Zoom",
+          accelerator: isMac ? "Cmd+0" : "Ctrl+0",
           click: (_menuItem, browserWindow) => {
             const win = browserWindow || BrowserWindow.getFocusedWindow();
             if (!win) return;
             win.webContents.setZoomLevel(0);
-          }
+          },
         },
-        {role: 'zoomin'},
-        {role: 'zoomout'},
+        { role: "zoomin" },
+        { role: "zoomout" },
         // {type: 'separator'}
         // {role: 'togglefullscreen'}
-      ]
+      ],
     },
     {
-      label: 'Window',
+      label: "Window",
       submenu: [
         {
-          label: 'Reload',
-          accelerator: isMac ? 'Cmd+R' : 'Ctrl+R',
-          click: (menuItem, bw) => { if (bw) bw.webContents.reload(); }
+          label: "Reload",
+          accelerator: isMac ? "Cmd+R" : "Ctrl+R",
+          click: (menuItem, bw) => {
+            if (bw) bw.webContents.reload();
+          },
         },
         {
-          label: 'Force Reload',
-          accelerator: isMac ? 'Shift+Cmd+R' : 'Ctrl+Shift+R',
-          click: (menuItem, bw) => { if (bw) bw.webContents.reloadIgnoringCache(); }
+          label: "Force Reload",
+          accelerator: isMac ? "Shift+Cmd+R" : "Ctrl+Shift+R",
+          click: (menuItem, bw) => {
+            if (bw) bw.webContents.reloadIgnoringCache();
+          },
         },
         {
-          label: 'Toggle Developer Tools',
-          accelerator: isMac ? 'Alt+Cmd+I' : 'Ctrl+Shift+I',
-          click: (menuItem, bw) => { if (bw) bw.webContents.toggleDevTools(); }
-        }
+          label: "Toggle Developer Tools",
+          accelerator: isMac ? "Alt+Cmd+I" : "Ctrl+Shift+I",
+          click: (menuItem, bw) => {
+            if (bw) bw.webContents.toggleDevTools();
+          },
+        },
         // {role: 'minimize'},
         // {role: 'zoom'},
         // {type: 'separator'},
         // {role: 'front'},
         // {role: 'window'}
-      ]
-    }
+      ],
+    },
   ];
 
   if (isMac) {
-    template.unshift(  {
+    template.unshift({
       label: app.name, // <--- This name will NOT show up in the macOS app menu, will need to update the Info.plist in the Electron folder
       submenu: [
-        {role: 'hide'},
-        {role: 'hideothers'},
-        {role: 'unhide'},
-        {type: 'separator'},
-        {role: 'quit'}
-      ]
+        { role: "hide" },
+        { role: "hideothers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" },
+      ],
     });
   }
-    // Removed:
-    /**
+  // Removed:
+  /**
           {role: 'about'},
           {type: 'separator'},
           {role: 'services'},
           {type: 'separator'},
     */
 
-    try {
-      const initialMenu = Menu.getApplicationMenu();
-      // console.log('initialMenu', initialMenu);
+  try {
+    const initialMenu = Menu.getApplicationMenu();
+    // console.log('initialMenu', initialMenu);
 
-      // build menu
-      // const menu = isMac ? Menu.buildFromTemplate(template) : [];
-      const menu = Menu.buildFromTemplate(template);
-      Menu.setApplicationMenu(menu);
-      //console.log('Menu set successfully');
+    // build menu
+    // const menu = isMac ? Menu.buildFromTemplate(template) : [];
+    const menu = Menu.buildFromTemplate(template);
+    Menu.setApplicationMenu(menu);
+    //console.log('Menu set successfully');
 
-      const currentMenu = Menu.getApplicationMenu();
-      // console.log('Current application menu:', currentMenu ? 'Set successfully' : 'Not set');
-      // console.log('currentMenu', currentMenu);
-    } catch (error) {
-      console.error('Failed to set application menu:', error);
-    }
+    const currentMenu = Menu.getApplicationMenu();
+    // console.log('Current application menu:', currentMenu ? 'Set successfully' : 'Not set');
+    // console.log('currentMenu', currentMenu);
+  } catch (error) {
+    console.error("Failed to set application menu:", error);
+  }
 }
 
 /**
@@ -305,177 +339,248 @@ function InitializeMenu() {
  * @returns {Promise<unknown>}
  */
 function delay(ms) {
-  return new Promise((resolve) =>
-    setTimeout(resolve, ms)
-  );
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function handleSetCanClose(event, newCanClose) {
-    canClose = newCanClose;
+  canClose = newCanClose;
 }
 
 function createWindow() {
+  console.log("resourcesDir is " + env.APP_RESOURCES_DIR);
 
-  console.log('resourcesDir is ' + env.APP_RESOURCES_DIR);
+  delay(500).then(() => {
+    // console.log('createWindow() - dev viewer');
+    const win = new BrowserWindow({
+      width: 1024,
+      height: 768,
+      minWidth: 900,
+      minHeight: 600,
+      autoHideMenuBar: false,
+      show: false, // Don't show until ready to maximize
+      icon: path.join(__dirname, "favicon.png"),
+      webPreferences: {
+        preload: path.join(__dirname, "preload.js"),
+        nodeIntegration: false, //default is also false. True leads to console error.
+        contextIsolation: true, //default is also true. What is the impact of changing this to false?
+        enableRemoteModule: false, //default is also false. What is the impact of changing this to true?
+        sandbox: false, // default is also false
+      },
+    });
 
-    delay(500).then(() => {
-        // console.log('createWindow() - dev viewer');
-        const win = new BrowserWindow({
-            width: 1024,
-            height: 768,
-            minWidth: 900,
-            minHeight: 600,
-            autoHideMenuBar: false,
-            show: false,  // Don't show until ready to maximize
-            icon: path.join(__dirname, 'favicon.png'),
-            webPreferences: {
-                preload: path.join(__dirname, 'preload.js'),
-                nodeIntegration: false, //default is also false. True leads to console error.
-                contextIsolation: true, //default is also true. What is the impact of changing this to false?
-                enableRemoteModule: false, //default is also false. What is the impact of changing this to true?
-                sandbox: false, // default is also false
-              }
-        });
+    win.once("ready-to-show", () => {
+      win.maximize();
+      win.show();
+      setTimeout(() => {
+        InitializeMenu();
+        win.show();
+        win.maximize();
+      }, 300);
+    });
 
-        win.once('ready-to-show', () => {
-            win.maximize();
-            win.show();
-            setTimeout(() => {
-                InitializeMenu();
-                win.show();
-                win.maximize();
-              }, 300);
-        });
-
-        // Show a dialog to the user to confirm the close
-        win.on('close', (event) => {
-            if (!canClose) {
-                event.preventDefault();
-                dialog.showMessageBox(win, {
-                    type: 'question',
-                    title: 'Unsaved changes',
-                    message: 'You have unsaved changes. Are you sure you want to close the application?',
-                    buttons: ['Yes', 'No'],
-                }).then((result) => {
-                    if (result.response === 0) {
-                        canClose = true;
-                        win.close();
-                    }
-                });
+    // Show a dialog to the user to confirm the close
+    win.on("close", (event) => {
+      if (!canClose) {
+        event.preventDefault();
+        dialog
+          .showMessageBox(win, {
+            type: "question",
+            title: "Unsaved changes",
+            message:
+              "You have unsaved changes. Are you sure you want to close the application?",
+            buttons: ["Yes", "No"],
+          })
+          .then((result) => {
+            if (result.response === 0) {
+              canClose = true;
+              win.close();
             }
-        });
+          });
+      }
+    });
 
-        // Show a dialog to the user switch pages
-        win.webContents.on('will-navigate', async (event, url) => {
-            if (!canClose) {
-                event.preventDefault();
-                dialog.showMessageBox(win, {
-                    title: 'Unsaved changes',
-                    type: 'question',
-                    message: 'You have unsaved changes. Are you sure you want to leave this page?',
-                    buttons: ['Yes', 'No'],
-                }).then((result) => {
-                    if (result.response === 0) {
-                        canClose = true;
-                        win.loadURL(url);
-                    }
-                });
+    // Show a dialog to the user switch pages
+    win.webContents.on("will-navigate", async (event, url) => {
+      if (!canClose) {
+        event.preventDefault();
+        dialog
+          .showMessageBox(win, {
+            title: "Unsaved changes",
+            type: "question",
+            message:
+              "You have unsaved changes. Are you sure you want to leave this page?",
+            buttons: ["Yes", "No"],
+          })
+          .then((result) => {
+            if (result.response === 0) {
+              canClose = true;
+              win.loadURL(url);
             }
-        });
+          });
+      }
+    });
 
-        win.loadURL(`http://127.0.0.1:${env.ROCKET_PORT}`);
-    })
-
+    win.loadURL(`http://127.0.0.1:${env.ROCKET_PORT}`);
+  });
 }
 
 app.whenReady().then(() => {
-  ipcMain.on('setCanClose', handleSetCanClose);
+  ipcMain.on("setCanClose", handleSetCanClose);
 
   // IPC: Check if Firefox browser engine is already downloaded
-  ipcMain.handle('check-firefox-installed', async () => {
+  ipcMain.handle("check-firefox-installed", async () => {
     return isFirefoxInstalled();
   });
 
   // IPC: Download Firefox browser engine on user request
-  ipcMain.on('download-firefox', async (event) => {
-    console.log('download-firefox triggered');
-    console.log('Cache dir:', BROWSER_CACHE_DIR);
-    console.log('Build ID:', FIREFOX_BUILD_ID);
-    console.log('Platform:', process.platform);
+  ipcMain.on("download-firefox", async (event) => {
+    console.log("download-firefox triggered");
+    console.log("Cache dir:", BROWSER_CACHE_DIR);
+    console.log("Build ID:", FIREFOX_BUILD_ID);
+    console.log("Platform:", process.platform);
 
     try {
-      if (process.platform === 'win32') {
+      if (process.platform === "win32") {
         await downloadFirefoxWindows(event);
       } else {
         await downloadFirefoxDefault(event);
       }
-      event.sender.send('download-complete', true);
+      event.sender.send("download-complete", true);
     } catch (err) {
-      console.error('Firefox download failed:', err.message);
-      console.error('Full error:', err);
-      event.sender.send('download-complete', false, err.message);
+      console.error("Firefox download failed:", err.message);
+      console.error("Full error:", err);
+      event.sender.send("download-complete", false, err.message);
     }
   });
-  
-  ipcMain.handle("generate-pdf", async (event, uuid) => {
+
+  ipcMain.handle("generate-pdf-temp", async (event, uuid) => {
     // Ensure Firefox is installed before attempting PDF generation
     if (!isFirefoxInstalled()) {
-      throw new Error('Firefox browser engine is not installed. Please download it first.');
+      throw new Error(
+        "Firefox browser engine is not installed. Please download it first.",
+      );
     }
-
-    const result = await dialog.showSaveDialog();
-    if (result.canceled) return null;
 
     const browser = await puppeteer.launch({
       headless: true,
       browser: "firefox",
+      // args: ["-safe-mode"],
       executablePath: getFirefoxExecutablePath(),
+      extraPrefsFirefox: {
+        "browser.startup.page": 1,
+        "print.always_print_silent": true, // skip print dialog
+        "print.show_print_progress": false, // disable progress UI
+        "pdfjs.disabled": true, // don't intercept with PDF.js
+      },
+      protocolTimeout: 900000, // ← fixes your exact error
+      timeout: 900000,
+    });
+    // const result = await dialog.showSaveDialog();
+
+    const page = await browser.newPage();
+    page.setDefaultTimeout(900000);
+    page.setDefaultNavigationTimeout(900000);
+    // Fetch HTML from temp storage
+    const response = await fetch(
+      `http://127.0.0.1:${env.ROCKET_PORT}/api/temp/bytes/${uuid}`,
+      {
+        method: "GET",
+      },
+    );
+
+    const resultHTML = await response.text();
+
+    await page.setContent(resultHTML, {
+      waitUntil: "networkidle0",
     });
 
-    try {
-      const page = await browser.newPage();
-      const response = await fetch(
-        `http://127.0.0.1:${env.ROCKET_PORT}/temp/bytes/${uuid}`,
-        {
-          method: "GET",
-        },
-      );
+    await page.evaluate(async () => {
+      await new Promise((resolve) => {
+        let lastHeight = 0;
 
-      const resultHTML = await response.text();
-      await page.setContent(resultHTML, {
-        waitUntil: "networkidle0",
+        const check = setInterval(() => {
+          window.scrollTo(0, document.body.scrollHeight);
+
+          if (document.body.scrollHeight === lastHeight) {
+            clearInterval(check);
+            resolve();
+          }
+
+          lastHeight = document.body.scrollHeight;
+        }, 400);
       });
+    });
+    // await page.waitForSelector("#print-ready-marker");
+    // Generate PDF buffer directly
+    const pdfBuffer = await page.pdf({
+      format: "A3",
+      printBackground: true,
+      timeout: 900000, // 5 minutes
+    });
+    // Create multipart form
+    const formData = new FormData();
 
-      await page.evaluate(() => document.fonts.ready);
+    const blob = new Blob([pdfBuffer], {
+      type: "application/pdf",
+    });
 
-      await page.pdf({
-        path: result.filePath,
-        format: "A3",
-        printBackground: true,
-      });
+    formData.append("file", blob, "document.pdf");
 
-      return result.filePath;
-    } finally {
-      await browser.close();
-    }
+    // Upload PDF to temp endpoint
+    const uploadResponse = await fetch(
+      `http://127.0.0.1:${env.ROCKET_PORT}/api/temp/bytes`,
+      {
+        method: "POST",
+        body: formData,
+      },
+    );
 
-    return result.filePath;
+    const uploadResult = await uploadResponse.json();
+
+    // returns { uuid: "..." }
+    // await browser.close();
+    return JSON.parse(JSON.stringify(uploadResult.uuid));
   });
+  ipcMain.handle("generate-pdf-final", async (event, uuid) => {
+  const response = await fetch(
+    `http://127.0.0.1:${env.ROCKET_PORT}/api/temp/bytes/${uuid}`,
+    {
+      method: "GET",
+    }
+  );
+
+  // Convert response to binary data
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  // Get Downloads folder
+  const downloadsPath = app.getPath("downloads");
+
+  // Create file name
+  const filePath = path.join(downloadsPath, `document-${uuid}.pdf`);
+
+  // Write file
+  fs.writeFileSync(filePath, buffer);
+
+  return filePath;
+});
   setTimeout(createWindow, 0); // Do not wait for server to start (dev viewer)
 });
 
-app.on('window-all-closed', () => {
-  console.log('window-all-closed() - app quitting');
+app.on("window-all-closed", () => {
+  console.log("window-all-closed() - app quitting");
   // On macOS, apps are expected to stay alive until explicitly quit
   // but we quit anyway so server doesn't remain running
   app.quit();
 });
 
-app.on('activate', () => {
+app.on("activate", () => {
   if (BrowserWindow.getAllWindows().length === 0) {
-    console.log('activate() - app creating window since there are none');
+    console.log("activate() - app creating window since there are none");
     createWindow();
   } else {
-    console.log('activate() - app not creating window since there are already windows');
+    console.log(
+      "activate() - app not creating window since there are already windows",
+    );
   }
 });

--- a/buildResources/electron/electronDevStartup.js
+++ b/buildResources/electron/electronDevStartup.js
@@ -6,6 +6,7 @@
  * - Application window management
  * - Custom menu creation (especially for macOS)
  * - Application events and shutdown procedures
+ * - On-demand Firefox browser engine download for Puppeteer
  *
  * @description
  * The script manages the lifecycle of the Electron frontend. (This is the dev viewer version; The backend server process is handled separately.)
@@ -24,6 +25,18 @@ const { app, BrowserWindow, Menu, shell, ipcMain, ipcRenderer, contextBridge, di
 const { spawn, execSync } = require('child_process');
 const path = require('path');
 const net = require('net');
+const fs = require('fs');
+const puppeteer = require('puppeteer-core');
+const os = require('os');
+const { install, computeExecutablePath } = require('@puppeteer/browsers');
+const { pipeline } = require('stream/promises');
+
+const FIREFOX_VERSION = '149.0.2';
+const FIREFOX_BUILD_ID = 'stable_' + FIREFOX_VERSION;
+const BROWSER_CACHE_DIR = path.join(app.getPath('userData'), 'browsers');
+
+// Where the extracted Firefox binary lives on Windows
+const FIREFOX_WIN_EXTRACT_DIR = path.join(BROWSER_CACHE_DIR, 'firefox', 'win64-' + FIREFOX_BUILD_ID);
 
 const env = {
   ...process.env,
@@ -66,6 +79,119 @@ getPort()
 
 app.name = '${APP_NAME}';
 let canClose = true;
+
+// Helper to get the Firefox executable path (used by generate-pdf)
+function getFirefoxExecutablePath() {
+  return computeExecutablePath({
+    browser: 'firefox',
+    buildId: FIREFOX_BUILD_ID,
+    cacheDir: BROWSER_CACHE_DIR,
+  });
+}
+
+// Helper to check if Firefox browser engine is downloaded
+function isFirefoxInstalled() {
+  try {
+    const exePath = getFirefoxExecutablePath();
+    return fs.existsSync(exePath);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Downloads and extracts Firefox on Windows using the silent /ExtractDir flag.
+ * This avoids running the installer and won't touch any existing Firefox installation.
+ */
+async function downloadFirefoxWindows(event) {
+  const url = `https://archive.mozilla.org/pub/firefox/releases/${FIREFOX_VERSION}/win64/en-US/Firefox%20Setup%20${FIREFOX_VERSION}.exe`;
+  const tempExe = path.join(os.tmpdir(), `firefox-setup-${FIREFOX_VERSION}.exe`);
+  const extractDir = FIREFOX_WIN_EXTRACT_DIR;
+
+  console.log('Download URL:', url);
+  console.log('Temp file:', tempExe);
+  console.log('Extract to:', extractDir);
+
+  // Step 1: Download the .exe with progress
+  event.sender.send('download-progress', 0);
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Download failed: HTTP ${response.status} from ${url}`);
+  }
+
+  const totalBytes = parseInt(response.headers.get('content-length'), 10) || 0;
+  let downloadedBytes = 0;
+
+  // Ensure temp directory exists
+  fs.mkdirSync(path.dirname(tempExe), { recursive: true });
+
+  const fileStream = fs.createWriteStream(tempExe);
+  const reader = response.body.getReader();
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    fileStream.write(Buffer.from(value));
+    downloadedBytes += value.length;
+    if (totalBytes > 0) {
+      const percent = Math.round((downloadedBytes / totalBytes) * 100);
+      event.sender.send('download-progress', percent);
+    }
+  }
+
+  fileStream.end();
+  await new Promise((resolve, reject) => {
+    fileStream.on('finish', resolve);
+    fileStream.on('error', reject);
+  });
+
+  console.log('Download complete, extracting...');
+  event.sender.send('download-progress', 100);
+
+// Step 2: Extract the self-extracting 7z archive
+const _7z = require('7zip-min');
+
+await new Promise((resolve, reject) => {
+  _7z.unpack(tempExe, extractDir, (err) => {
+    if (err) reject(new Error(`Firefox extraction failed: ${err.message}`));
+    else resolve();
+  });
+});
+
+  // Step 3: Clean up temp file
+  try {
+    fs.unlinkSync(tempExe);
+    console.log('Temp file cleaned up');
+  } catch {
+    console.warn('Could not delete temp file:', tempExe);
+  }
+
+  // Step 4: Verify extraction
+  const exePath = getFirefoxExecutablePath();
+  if (!fs.existsSync(exePath)) {
+    throw new Error(`Extraction appeared to succeed but firefox.exe not found at: ${exePath}`);
+  }
+
+  console.log('Firefox extracted successfully to:', exePath);
+}
+
+/**
+ * Downloads Firefox on macOS/Linux using @puppeteer/browsers install().
+ */
+async function downloadFirefoxDefault(event) {
+  await install({
+    browser: 'firefox',
+    buildId: FIREFOX_BUILD_ID,
+    cacheDir: BROWSER_CACHE_DIR,
+    onProgress: (downloadedBytes, totalBytes) => {
+      if (totalBytes > 0) {
+        const percent = Math.round((downloadedBytes / totalBytes) * 100);
+        event.sender.send('download-progress', percent);
+      }
+    },
+  });
+}
 
 function InitializeMenu() {
   const isMac = process.platform === 'darwin';
@@ -259,6 +385,70 @@ function createWindow() {
 app.whenReady().then(() => {
   ipcMain.on('setCanClose', handleSetCanClose);
 
+  // IPC: Check if Firefox browser engine is already downloaded
+  ipcMain.handle('check-firefox-installed', async () => {
+    return isFirefoxInstalled();
+  });
+
+  // IPC: Download Firefox browser engine on user request
+  ipcMain.on('download-firefox', async (event) => {
+    console.log('download-firefox triggered');
+    console.log('Cache dir:', BROWSER_CACHE_DIR);
+    console.log('Build ID:', FIREFOX_BUILD_ID);
+    console.log('Platform:', process.platform);
+
+    try {
+      if (process.platform === 'win32') {
+        await downloadFirefoxWindows(event);
+      } else {
+        await downloadFirefoxDefault(event);
+      }
+      event.sender.send('download-complete', true);
+    } catch (err) {
+      console.error('Firefox download failed:', err.message);
+      console.error('Full error:', err);
+      event.sender.send('download-complete', false);
+    }
+  });
+  
+  ipcMain.handle("generate-pdf", async (event, uuid) => {
+    // Ensure Firefox is installed before attempting PDF generation
+    if (!isFirefoxInstalled()) {
+      throw new Error('Firefox browser engine is not installed. Please download it first.');
+    }
+
+    const browser = await puppeteer.launch({
+      headless: "new",
+      browser: "firefox",
+      executablePath: getFirefoxExecutablePath(),
+    });
+    const result = await dialog.showSaveDialog();
+
+    const page = await browser.newPage();
+    const response = await fetch(
+      `http://127.0.0.1:${env.ROCKET_PORT}/temp/bytes/${uuid}`,
+      {
+        method: "GET",
+      },
+    );
+
+    const resultHTML = await response.text();
+    await page.setContent(resultHTML, {
+      waitUntil: "networkidle0",
+    });
+
+    await page.evaluate(() => document.fonts.ready);
+
+    await page.pdf({
+      path: result.filePath,
+      format: "A3",
+      printBackground: true,
+    });
+
+    await browser.close();
+
+    return result.filePath;
+  });
   setTimeout(createWindow, 0); // Do not wait for server to start (dev viewer)
 });
 

--- a/buildResources/electron/electronDevStartup.js
+++ b/buildResources/electron/electronDevStartup.js
@@ -180,12 +180,18 @@ await new Promise((resolve, reject) => {
  * Downloads Firefox on macOS/Linux using @puppeteer/browsers install().
  */
 async function downloadFirefoxDefault(event) {
+  event.sender.send('download-progress', null);
+
   await install({
     browser: 'firefox',
     buildId: FIREFOX_BUILD_ID,
     cacheDir: BROWSER_CACHE_DIR,
     onProgress: (downloadedBytes, totalBytes) => {
-      if (totalBytes > 0) {
+      if (
+        typeof downloadedBytes === 'number' &&
+        typeof totalBytes === 'number' &&
+        totalBytes > 0
+      ) {
         const percent = Math.round((downloadedBytes / totalBytes) * 100);
         event.sender.send('download-progress', percent);
       }

--- a/buildResources/electron/electronDevStartup.js
+++ b/buildResources/electron/electronDevStartup.js
@@ -407,7 +407,7 @@ app.whenReady().then(() => {
     } catch (err) {
       console.error('Firefox download failed:', err.message);
       console.error('Full error:', err);
-      event.sender.send('download-complete', false);
+      event.sender.send('download-complete', false, err.message);
     }
   });
   

--- a/buildResources/electron/electronDevStartup.js
+++ b/buildResources/electron/electronDevStartup.js
@@ -418,7 +418,7 @@ app.whenReady().then(() => {
     }
 
     const browser = await puppeteer.launch({
-      headless: "new",
+      headless: true,
       browser: "firefox",
       executablePath: getFirefoxExecutablePath(),
     });

--- a/buildResources/electron/electronStartup.js
+++ b/buildResources/electron/electronStartup.js
@@ -468,7 +468,7 @@ app.whenReady().then(() => {
     } catch (err) {
       console.error('Firefox download failed:', err.message);
       console.error('Full error:', err);
-      event.sender.send('download-complete', false);
+      event.sender.send('download-complete', false, err.message);
     }
   });
 

--- a/buildResources/electron/electronStartup.js
+++ b/buildResources/electron/electronStartup.js
@@ -35,7 +35,7 @@ const { pipeline } = require('stream/promises');
 
 const FIREFOX_VERSION = '149.0.2';
 const FIREFOX_BUILD_ID = 'stable_' + FIREFOX_VERSION;
-const BROWSER_CACHE_DIR = path.join(app.getPath('userData'), 'browsers');
+const BROWSER_CACHE_DIR = path.join(app.getPath('home'), 'pankosmia', '_assets');
 
 // Where the extracted Firefox binary lives on Windows
 const FIREFOX_WIN_EXTRACT_DIR = path.join(BROWSER_CACHE_DIR, 'firefox', 'win64-' + FIREFOX_BUILD_ID);

--- a/buildResources/electron/electronStartup.js
+++ b/buildResources/electron/electronStartup.js
@@ -478,54 +478,120 @@ app.whenReady().then(() => {
     }
   });
 
-  ipcMain.handle("generate-pdf", async (event, uuid) => {
+  ipcMain.handle("generate-pdf-temp", async (event, uuid) => {
     // Ensure Firefox is installed before attempting PDF generation
     if (!isFirefoxInstalled()) {
-      throw new Error('Firefox browser engine is not installed. Please download it first.');
+      throw new Error(
+        "Firefox browser engine is not installed. Please download it first.",
+      );
     }
-
-    const result = await dialog.showSaveDialog();
-    if (result.canceled) return null;
 
     const browser = await puppeteer.launch({
       headless: true,
       browser: "firefox",
+      // args: ["-safe-mode"],
       executablePath: getFirefoxExecutablePath(),
+      extraPrefsFirefox: {
+        "browser.startup.page": 1,
+        "print.always_print_silent": true, // skip print dialog
+        "print.show_print_progress": false, // disable progress UI
+        "pdfjs.disabled": true, // don't intercept with PDF.js
+      },
+      protocolTimeout: 900000, // ← fixes your exact error
+      timeout: 900000,
+    });
+    // const result = await dialog.showSaveDialog();
+
+    const page = await browser.newPage();
+    page.setDefaultTimeout(900000);
+    page.setDefaultNavigationTimeout(900000);
+    // Fetch HTML from temp storage
+    const response = await fetch(
+      `http://127.0.0.1:${env.ROCKET_PORT}/api/temp/bytes/${uuid}`,
+      {
+        method: "GET",
+      },
+    );
+
+    const resultHTML = await response.text();
+
+    await page.setContent(resultHTML, {
+      waitUntil: "networkidle0",
     });
 
-    try {
-      const page = await browser.newPage();
-      const response = await fetch(
-        `http://127.0.0.1:${env.ROCKET_PORT}/temp/bytes/${uuid}`,
-        {
-          method: "GET",
-        },
-      );
+    await page.evaluate(async () => {
+      await new Promise((resolve) => {
+        let lastHeight = 0;
 
-      const resultHTML = await response.text();
-      await page.setContent(resultHTML, {
-        waitUntil: "networkidle0",
+        const check = setInterval(() => {
+          window.scrollTo(0, document.body.scrollHeight);
+
+          if (document.body.scrollHeight === lastHeight) {
+            clearInterval(check);
+            resolve();
+          }
+
+          lastHeight = document.body.scrollHeight;
+        }, 400);
       });
+    });
+    // await page.waitForSelector("#print-ready-marker");
+    // Generate PDF buffer directly
+    const pdfBuffer = await page.pdf({
+      format: "A3",
+      printBackground: true,
+      timeout: 900000, // 5 minutes
+    });
+    // Create multipart form
+    const formData = new FormData();
 
-      await page.evaluate(() => document.fonts.ready);
+    const blob = new Blob([pdfBuffer], {
+      type: "application/pdf",
+    });
 
-      await page.pdf({
-        path: result.filePath,
-        format: "A3",
-        printBackground: true,
-      });
+    formData.append("file", blob, "document.pdf");
 
-      return result.filePath;
-    } finally {
-      await browser.close();
+    // Upload PDF to temp endpoint
+    const uploadResponse = await fetch(
+      `http://127.0.0.1:${env.ROCKET_PORT}/api/temp/bytes`,
+      {
+        method: "POST",
+        body: formData,
+      },
+    );
+
+    const uploadResult = await uploadResponse.json();
+
+    // returns { uuid: "..." }
+    // await browser.close();
+    return JSON.parse(JSON.stringify(uploadResult.uuid));
+  });
+  ipcMain.handle("generate-pdf-final", async (event, uuid) => {
+  const response = await fetch(
+    `http://127.0.0.1:${env.ROCKET_PORT}/api/temp/bytes/${uuid}`,
+    {
+      method: "GET",
     }
+  );
 
-    return result.filePath;
-  });  
-  startServer();
-  setTimeout(createWindow, 2000); // Wait 2 seconds for server to start (adjust as needed)
+  // Convert response to binary data
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  // Get Downloads folder
+  const downloadsPath = app.getPath("downloads");
+
+  // Create file name
+  const filePath = path.join(downloadsPath, `document-${uuid}.pdf`);
+
+  // Write file
+  fs.writeFileSync(filePath, buffer);
+
+  return filePath;
 });
 
+  setTimeout(createWindow, 0); // Do not wait for server to start (dev viewer)
+});
 app.on('window-all-closed', () => {
   console.log('window-all-closed() - app quitting');
   // On macOS, apps are expected to stay alive until explicitly quit

--- a/buildResources/electron/electronStartup.js
+++ b/buildResources/electron/electronStartup.js
@@ -194,12 +194,18 @@ await new Promise((resolve, reject) => {
  * Downloads Firefox on macOS/Linux using @puppeteer/browsers install().
  */
 async function downloadFirefoxDefault(event) {
+  event.sender.send('download-progress', null);
+
   await install({
     browser: 'firefox',
     buildId: FIREFOX_BUILD_ID,
     cacheDir: BROWSER_CACHE_DIR,
     onProgress: (downloadedBytes, totalBytes) => {
-      if (totalBytes > 0) {
+      if (
+        typeof downloadedBytes === 'number' &&
+        typeof totalBytes === 'number' &&
+        totalBytes > 0
+      ) {
         const percent = Math.round((downloadedBytes / totalBytes) * 100);
         event.sender.send('download-progress', percent);
       }

--- a/buildResources/electron/electronStartup.js
+++ b/buildResources/electron/electronStartup.js
@@ -7,6 +7,7 @@
  * - Backend server process lifecycle
  * - Custom menu creation (especially for macOS)
  * - Application events and shutdown procedures
+ * - On-demand Firefox browser engine download for Puppeteer
  *
  * @description
  * The script manages the lifecycle of both the Electron frontend and a backend server process.
@@ -26,6 +27,18 @@ const { app, BrowserWindow, Menu, shell, ipcMain, ipcRenderer, contextBridge, di
 const { spawn, execSync } = require('child_process');
 const path = require('path');
 const net = require('net');
+const fs = require('fs');
+const puppeteer = require('puppeteer-core');
+const os = require('os');
+const { install, computeExecutablePath } = require('@puppeteer/browsers');
+const { pipeline } = require('stream/promises');
+
+const FIREFOX_VERSION = '149.0.2';
+const FIREFOX_BUILD_ID = 'stable_' + FIREFOX_VERSION;
+const BROWSER_CACHE_DIR = path.join(app.getPath('userData'), 'browsers');
+
+// Where the extracted Firefox binary lives on Windows
+const FIREFOX_WIN_EXTRACT_DIR = path.join(BROWSER_CACHE_DIR, 'firefox', 'win64-' + FIREFOX_BUILD_ID);
 
 const env = {
   ...process.env,
@@ -79,6 +92,119 @@ function isServerRunning() {
   } catch {
     return false;
   }
+}
+
+// Helper to get the Firefox executable path (used by generate-pdf)
+function getFirefoxExecutablePath() {
+  return computeExecutablePath({
+    browser: 'firefox',
+    buildId: FIREFOX_BUILD_ID,
+    cacheDir: BROWSER_CACHE_DIR,
+  });
+}
+
+// Helper to check if Firefox browser engine is downloaded
+function isFirefoxInstalled() {
+  try {
+    const exePath = getFirefoxExecutablePath();
+    return fs.existsSync(exePath);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Downloads and extracts Firefox on Windows using the silent /ExtractDir flag.
+ * This avoids running the installer and won't touch any existing Firefox installation.
+ */
+async function downloadFirefoxWindows(event) {
+  const url = `https://archive.mozilla.org/pub/firefox/releases/${FIREFOX_VERSION}/win64/en-US/Firefox%20Setup%20${FIREFOX_VERSION}.exe`;
+  const tempExe = path.join(os.tmpdir(), `firefox-setup-${FIREFOX_VERSION}.exe`);
+  const extractDir = FIREFOX_WIN_EXTRACT_DIR;
+
+  console.log('Download URL:', url);
+  console.log('Temp file:', tempExe);
+  console.log('Extract to:', extractDir);
+
+  // Step 1: Download the .exe with progress
+  event.sender.send('download-progress', 0);
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Download failed: HTTP ${response.status} from ${url}`);
+  }
+
+  const totalBytes = parseInt(response.headers.get('content-length'), 10) || 0;
+  let downloadedBytes = 0;
+
+  // Ensure temp directory exists
+  fs.mkdirSync(path.dirname(tempExe), { recursive: true });
+
+  const fileStream = fs.createWriteStream(tempExe);
+  const reader = response.body.getReader();
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    fileStream.write(Buffer.from(value));
+    downloadedBytes += value.length;
+    if (totalBytes > 0) {
+      const percent = Math.round((downloadedBytes / totalBytes) * 100);
+      event.sender.send('download-progress', percent);
+    }
+  }
+
+  fileStream.end();
+  await new Promise((resolve, reject) => {
+    fileStream.on('finish', resolve);
+    fileStream.on('error', reject);
+  });
+
+  console.log('Download complete, extracting...');
+  event.sender.send('download-progress', 100);
+
+// Step 2: Extract the self-extracting 7z archive
+const _7z = require('7zip-min');
+
+await new Promise((resolve, reject) => {
+  _7z.unpack(tempExe, extractDir, (err) => {
+    if (err) reject(new Error(`Firefox extraction failed: ${err.message}`));
+    else resolve();
+  });
+});
+
+  // Step 3: Clean up temp file
+  try {
+    fs.unlinkSync(tempExe);
+    console.log('Temp file cleaned up');
+  } catch {
+    console.warn('Could not delete temp file:', tempExe);
+  }
+
+  // Step 4: Verify extraction
+  const exePath = getFirefoxExecutablePath();
+  if (!fs.existsSync(exePath)) {
+    throw new Error(`Extraction appeared to succeed but firefox.exe not found at: ${exePath}`);
+  }
+
+  console.log('Firefox extracted successfully to:', exePath);
+}
+
+/**
+ * Downloads Firefox on macOS/Linux using @puppeteer/browsers install().
+ */
+async function downloadFirefoxDefault(event) {
+  await install({
+    browser: 'firefox',
+    buildId: FIREFOX_BUILD_ID,
+    cacheDir: BROWSER_CACHE_DIR,
+    onProgress: (downloadedBytes, totalBytes) => {
+      if (totalBytes > 0) {
+        const percent = Math.round((downloadedBytes / totalBytes) * 100);
+        event.sender.send('download-progress', percent);
+      }
+    },
+  });
 }
 
 function InitializeMenu() {
@@ -318,7 +444,72 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
-  ipcMain.on('setCanClose', handleSetCanClose);  
+  ipcMain.on('setCanClose', handleSetCanClose);
+
+  // IPC: Check if Firefox browser engine is already downloaded
+  ipcMain.handle('check-firefox-installed', async () => {
+    return isFirefoxInstalled();
+  });
+
+  // IPC: Download Firefox browser engine on user request
+  ipcMain.on('download-firefox', async (event) => {
+    console.log('download-firefox triggered');
+    console.log('Cache dir:', BROWSER_CACHE_DIR);
+    console.log('Build ID:', FIREFOX_BUILD_ID);
+    console.log('Platform:', process.platform);
+
+    try {
+      if (process.platform === 'win32') {
+        await downloadFirefoxWindows(event);
+      } else {
+        await downloadFirefoxDefault(event);
+      }
+      event.sender.send('download-complete', true);
+    } catch (err) {
+      console.error('Firefox download failed:', err.message);
+      console.error('Full error:', err);
+      event.sender.send('download-complete', false);
+    }
+  });
+
+  ipcMain.handle("generate-pdf", async (event, uuid) => {
+    // Ensure Firefox is installed before attempting PDF generation
+    if (!isFirefoxInstalled()) {
+      throw new Error('Firefox browser engine is not installed. Please download it first.');
+    }
+
+    const browser = await puppeteer.launch({
+      headless: "new",
+      browser: "firefox",
+      executablePath: getFirefoxExecutablePath(),
+    });
+    const result = await dialog.showSaveDialog();
+
+    const page = await browser.newPage();
+    const response = await fetch(
+      `http://127.0.0.1:${env.ROCKET_PORT}/temp/bytes/${uuid}`,
+      {
+        method: "GET",
+      },
+    );
+
+    const resultHTML = await response.text();
+    await page.setContent(resultHTML, {
+      waitUntil: "networkidle0",
+    });
+
+    await page.evaluate(() => document.fonts.ready);
+
+    await page.pdf({
+      path: result.filePath,
+      format: "A3",
+      printBackground: true,
+    });
+
+    await browser.close();
+
+    return result.filePath;
+  });  
   startServer();
   setTimeout(createWindow, 2000); // Wait 2 seconds for server to start (adjust as needed)
 });

--- a/buildResources/electron/electronStartup.js
+++ b/buildResources/electron/electronStartup.js
@@ -478,35 +478,41 @@ app.whenReady().then(() => {
       throw new Error('Firefox browser engine is not installed. Please download it first.');
     }
 
+    const result = await dialog.showSaveDialog();
+    if (result.canceled) return null;
+
     const browser = await puppeteer.launch({
       headless: true,
       browser: "firefox",
       executablePath: getFirefoxExecutablePath(),
     });
-    const result = await dialog.showSaveDialog();
 
-    const page = await browser.newPage();
-    const response = await fetch(
-      `http://127.0.0.1:${env.ROCKET_PORT}/temp/bytes/${uuid}`,
-      {
-        method: "GET",
-      },
-    );
+    try {
+      const page = await browser.newPage();
+      const response = await fetch(
+        `http://127.0.0.1:${env.ROCKET_PORT}/temp/bytes/${uuid}`,
+        {
+          method: "GET",
+        },
+      );
 
-    const resultHTML = await response.text();
-    await page.setContent(resultHTML, {
-      waitUntil: "networkidle0",
-    });
+      const resultHTML = await response.text();
+      await page.setContent(resultHTML, {
+        waitUntil: "networkidle0",
+      });
 
-    await page.evaluate(() => document.fonts.ready);
+      await page.evaluate(() => document.fonts.ready);
 
-    await page.pdf({
-      path: result.filePath,
-      format: "A3",
-      printBackground: true,
-    });
+      await page.pdf({
+        path: result.filePath,
+        format: "A3",
+        printBackground: true,
+      });
 
-    await browser.close();
+      return result.filePath;
+    } finally {
+      await browser.close();
+    }
 
     return result.filePath;
   });  

--- a/buildResources/electron/electronStartup.js
+++ b/buildResources/electron/electronStartup.js
@@ -479,7 +479,7 @@ app.whenReady().then(() => {
     }
 
     const browser = await puppeteer.launch({
-      headless: "new",
+      headless: true,
       browser: "firefox",
       executablePath: getFirefoxExecutablePath(),
     });

--- a/buildResources/electron/preload.js
+++ b/buildResources/electron/preload.js
@@ -1,4 +1,26 @@
-const { contextBridge, ipcRenderer } = require('electron')
+const { contextBridge, ipcRenderer } = require('electron');
+
 contextBridge.exposeInMainWorld('electronAPI', {
-  setCanClose: (canClose) => ipcRenderer.send('setCanClose', canClose)
-})
+  // Existing
+  setCanClose: (canClose) => ipcRenderer.send('setCanClose', canClose),
+
+  // Firefox download
+  downloadFirefox: () => ipcRenderer.send('download-firefox'),
+  checkFirefoxInstalled: () => ipcRenderer.invoke('check-firefox-installed'),
+  onDownloadProgress: (callback) => {
+    const handler = (_event, percent) => callback(percent);
+    ipcRenderer.on('download-progress', handler);
+    return () => ipcRenderer.removeListener('download-progress', handler);
+  },
+  onDownloadComplete: (callback) => {
+    const handler = (_event, success) => callback(success);
+    ipcRenderer.on('download-complete', handler);
+    return () => ipcRenderer.removeListener('download-complete', handler);
+  },
+});
+
+contextBridge.exposeInMainWorld('api', {
+  // Existing
+  generatePdf: (uuid) => ipcRenderer.invoke('generate-pdf', uuid),
+
+});

--- a/buildResources/electron/preload.js
+++ b/buildResources/electron/preload.js
@@ -13,7 +13,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('download-progress', handler);
   },
   onDownloadComplete: (callback) => {
-    const handler = (_event, success) => callback(success);
+    const handler = (_event, success, errorMessage) => callback(success, errorMessage);
     ipcRenderer.on('download-complete', handler);
     return () => ipcRenderer.removeListener('download-complete', handler);
   },

--- a/buildResources/electron/preload.js
+++ b/buildResources/electron/preload.js
@@ -1,26 +1,27 @@
-const { contextBridge, ipcRenderer } = require('electron');
+const { contextBridge, ipcRenderer } = require("electron");
 
-contextBridge.exposeInMainWorld('electronAPI', {
+contextBridge.exposeInMainWorld("electronAPI", {
   // Existing
-  setCanClose: (canClose) => ipcRenderer.send('setCanClose', canClose),
+  setCanClose: (canClose) => ipcRenderer.send("setCanClose", canClose),
 
   // Firefox download
-  downloadFirefox: () => ipcRenderer.send('download-firefox'),
-  checkFirefoxInstalled: () => ipcRenderer.invoke('check-firefox-installed'),
+  downloadFirefox: () => ipcRenderer.send("download-firefox"),
+  checkFirefoxInstalled: () => ipcRenderer.invoke("check-firefox-installed"),
   onDownloadProgress: (callback) => {
     const handler = (_event, percent) => callback(percent);
-    ipcRenderer.on('download-progress', handler);
-    return () => ipcRenderer.removeListener('download-progress', handler);
+    ipcRenderer.on("download-progress", handler);
+    return () => ipcRenderer.removeListener("download-progress", handler);
   },
   onDownloadComplete: (callback) => {
-    const handler = (_event, success, errorMessage) => callback(success, errorMessage);
-    ipcRenderer.on('download-complete', handler);
-    return () => ipcRenderer.removeListener('download-complete', handler);
+    const handler = (_event, success, errorMessage) =>
+      callback(success, errorMessage);
+    ipcRenderer.on("download-complete", handler);
+    return () => ipcRenderer.removeListener("download-complete", handler);
   },
 });
 
-contextBridge.exposeInMainWorld('api', {
-  // Existing
-  generatePdf: (uuid) => ipcRenderer.invoke('generate-pdf', uuid),
-
+contextBridge.exposeInMainWorld("api", {
+  generatePdf: async (uuid) => ipcRenderer.invoke("generate-pdf-temp", uuid),
+  generatePdfToFile: async (uuid) =>
+    ipcRenderer.invoke("generate-pdf-final", uuid),
 });

--- a/buildResources/electron/puppeteer.config.js
+++ b/buildResources/electron/puppeteer.config.js
@@ -1,0 +1,6 @@
+// puppeteer.config.js
+const config = {
+  defaultProduct: 'firefox',
+};
+
+module.exports = config;

--- a/buildResources/electron/puppeteer.config.js
+++ b/buildResources/electron/puppeteer.config.js
@@ -1,6 +1,0 @@
-// puppeteer.config.js
-const config = {
-  defaultProduct: 'firefox',
-};
-
-module.exports = config;

--- a/linux/install/makeInstallElectronite.bsh
+++ b/linux/install/makeInstallElectronite.bsh
@@ -128,6 +128,25 @@ for mod in "${ALL_OS_MODULES[@]}"; do
     cp -R "${NODE_MODULES_SRC}/${mod}/." "${NODE_MODULES_DEST}/${mod}/"
 done
 
+LINUX_MODULES=(
+    "tar-fs"
+    "tar-stream"
+    "streamx"
+    "events-universal"
+    "fast-fifo"
+    "text-decoder"
+    "b4a"
+    "pump"
+    "once"
+    "wrappy"
+    "end-of-stream"
+)
+
+for mod in "${LINUX_MODULES[@]}"; do
+    mkdir -p "${NODE_MODULES_DEST}/${mod}"
+    cp -R "${NODE_MODULES_SRC}/${mod}/." "${NODE_MODULES_DEST}/${mod}/"
+done
+
 echo "Successfully copied node_modules dependencies"
 
 # Determine which startup to use -- dev viewer or production

--- a/linux/install/makeInstallElectronite.bsh
+++ b/linux/install/makeInstallElectronite.bsh
@@ -120,6 +120,7 @@ ALL_OS_MODULES=(
     "agent-base"
     "proxy-from-env"
     "progress"
+    "mitt"
 )
 
 for mod in "${ALL_OS_MODULES[@]}"; do

--- a/linux/install/makeInstallElectronite.bsh
+++ b/linux/install/makeInstallElectronite.bsh
@@ -100,6 +100,29 @@ cp -R ../../buildResources/electron ${APP_BASE_DIR}/
 cp ../../globalBuildResources/favicon*.png ${APP_BASE_DIR}/electron
 echo "Successfully copied electron files"
 
+# Copy required node_modules and dependencies -- all OSes
+NODE_MODULES_SRC="../../node_modules"
+NODE_MODULES_DEST="${APP_BASE_DIR}/electron/node_modules"
+
+ALL_OS_MODULES=(
+    "puppeteer-core"
+    "@puppeteer/browsers"
+    "chromium-bidi"
+    "debug"
+    "devtools-protocol"
+    "ms"
+    "typed-query-selector"
+    "webdriver-bidi-protocol"
+    "ws"
+)
+
+for mod in "${ALL_OS_MODULES[@]}"; do
+    mkdir -p "${NODE_MODULES_DEST}/${mod}"
+    cp -R "${NODE_MODULES_SRC}/${mod}/." "${NODE_MODULES_DEST}/${mod}/"
+done
+
+echo "Successfully copied node_modules dependencies"
+
 # Determine which startup to use -- dev viewer or production
 if [[ $devRun =~ ^(-d) ]]; then
   rm ${APP_BASE_DIR}/electron/electronStartup.js
@@ -126,9 +149,8 @@ if [ "$ELECTRON_OWNER" != "$CURRENT_USER" ]; then
 fi
 
 
-chmod 755 ${APP_BASE_DIR}/linux
-
 if ! [[ $devRun =~ ^(-d) ]]; then
+  chmod 755 ${APP_BASE_DIR}/linux
   cp -R ./bin ${APP_BASE_DIR}/
   echo "copied bin to $APP_BASE_DIR/"
   chmod 755 ${APP_BASE_DIR}/bin/server.bin

--- a/linux/install/makeInstallElectronite.bsh
+++ b/linux/install/makeInstallElectronite.bsh
@@ -114,6 +114,12 @@ ALL_OS_MODULES=(
     "typed-query-selector"
     "webdriver-bidi-protocol"
     "ws"
+    "semver"
+    "proxy-agent"
+    "lru-cache"
+    "agent-base"
+    "proxy-from-env"
+    "progress"
 )
 
 for mod in "${ALL_OS_MODULES[@]}"; do

--- a/macos/install/makeInstallElectronite.sh
+++ b/macos/install/makeInstallElectronite.sh
@@ -122,6 +122,12 @@ ALL_OS_MODULES=(
     "typed-query-selector"
     "webdriver-bidi-protocol"
     "ws"
+    "semver"
+    "proxy-agent"
+    "lru-cache"
+    "agent-base"
+    "proxy-from-env"
+    "progress"
 )
 
 for mod in "${ALL_OS_MODULES[@]}"; do

--- a/macos/install/makeInstallElectronite.sh
+++ b/macos/install/makeInstallElectronite.sh
@@ -128,6 +128,7 @@ ALL_OS_MODULES=(
     "agent-base"
     "proxy-from-env"
     "progress"
+    "mitt"
 )
 
 for mod in "${ALL_OS_MODULES[@]}"; do

--- a/macos/install/makeInstallElectronite.sh
+++ b/macos/install/makeInstallElectronite.sh
@@ -108,6 +108,29 @@ cp -R ../../buildResources/electron ${APP_BASE_DIR}/Contents/
 cp ../../globalBuildResources/favicon*.png ${APP_BASE_DIR}/Contents/electron
 echo "Successfully copied electron files"
 
+# Copy required node_modules and dependencies -- all OSes
+NODE_MODULES_SRC="../../node_modules"
+NODE_MODULES_DEST="${APP_BASE_DIR}/Contents/electron/node_modules"
+
+ALL_OS_MODULES=(
+    "puppeteer-core"
+    "@puppeteer/browsers"
+    "chromium-bidi"
+    "debug"
+    "devtools-protocol"
+    "ms"
+    "typed-query-selector"
+    "webdriver-bidi-protocol"
+    "ws"
+)
+
+for mod in "${ALL_OS_MODULES[@]}"; do
+    mkdir -p "${NODE_MODULES_DEST}/${mod}"
+    cp -R "${NODE_MODULES_SRC}/${mod}/." "${NODE_MODULES_DEST}/${mod}/"
+done
+
+echo "Successfully copied node_modules dependencies"
+
 # Determine which startup to use -- dev viewer or production
 if [[ $devRun =~ ^(-d) ]]; then
   rm ${APP_BASE_DIR}/Contents/electron/electronStartup.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,12 @@
       "license": "MIT",
       "dependencies": {
         "@dotenvx/dotenvx": "^1.44.2",
+        "@puppeteer/browsers": "^2.13.1",
+        "7zip-min": "^3.0.1",
         "copy-dir": "^1.3.0",
         "fs-extra": "^11.3.0",
-        "path": "^0.12.7"
+        "path": "^0.12.7",
+        "puppeteer-core": "^24.43.1"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -87,6 +90,281 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
+      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/7zip-bin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
+      "license": "MIT"
+    },
+    "node_modules/7zip-min": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/7zip-min/-/7zip-min-3.0.1.tgz",
+      "integrity": "sha512-WB4VCA/KSKzxhj+BAp8fI3ZYMMAftclkXlUTckuiDacsqyubQxxG3lGcpBcgzWWuJqnfQncEq1xrJpPLSxqsxw==",
+      "license": "MIT",
+      "dependencies": {
+        "7zip-bin": "5.1.1"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
@@ -132,6 +410,52 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/dotenv": {
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
@@ -159,6 +483,91 @@
         "node": ">=16"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -179,6 +588,56 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -207,6 +666,15 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -218,10 +686,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -243,6 +751,24 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -274,6 +800,15 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -285,6 +820,27 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -306,6 +862,15 @@
         "node": ">= 10"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -318,6 +883,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/path": {
@@ -337,6 +934,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -355,6 +958,89 @@
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+      "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.2",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -381,6 +1067,91 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -388,6 +1159,69 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -405,6 +1239,12 @@
         "inherits": "2.0.3"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/which": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
@@ -417,6 +1257,105 @@
       },
       "engines": {
         "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,15 @@
   },
   "homepage": "https://github.com/pankosmia/desktop-app-template#readme",
   "dependencies": {
-    "copy-dir": "^1.3.0",
     "@dotenvx/dotenvx": "^1.44.2",
+    "@puppeteer/browsers": "^2.13.1",
+    "7zip-min": "^3.0.1",
+    "copy-dir": "^1.3.0",
     "fs-extra": "^11.3.0",
-    "path": "^0.12.7"
+    "path": "^0.12.7",
+    "puppeteer-core": "^24.43.1"
+  },
+  "overrides": {
+    "7zip-bin": "5.2.0"
   }
 }

--- a/windows/install/makeInstallElectronite.ps1
+++ b/windows/install/makeInstallElectronite.ps1
@@ -178,6 +178,7 @@ try {
             "agent-base"
             "proxy-from-env"
             "progress"
+            "mitt"
         )
 
         foreach ($mod in $allOsModules) {

--- a/windows/install/makeInstallElectronite.ps1
+++ b/windows/install/makeInstallElectronite.ps1
@@ -144,6 +144,44 @@ try {
         Write-Host "Copying favicon*.png to $electronDestPath ..."
         Copy-Item $electronIconSrc -Destination $electronDestPath
 
+        # Copy required modules and dependencies
+        $nodeModulesSrc = Join-Path $PSScriptRoot "..\..\node_modules"
+        $nodeModulesDest = Join-Path $electronDestPath "node_modules"
+
+        # 7zip-min (full directory) -- Windows only
+        $7zipMinDest = Join-Path $nodeModulesDest "7zip-min"
+        New-Item -ItemType Directory -Path $7zipMinDest -Force | Out-Null
+        Copy-Item -Path (Join-Path $nodeModulesSrc "7zip-min\*") -Destination $7zipMinDest -Recurse -Force -ErrorAction Stop
+
+        # 7zip-bin (selective: index.js, package.json, and arch-specific binary) -- Windows only
+        $7zipBinDest = Join-Path $nodeModulesDest "7zip-bin"
+        $7zipBinWinArchDest = Join-Path $7zipBinDest "win\$arch"
+        New-Item -ItemType Directory -Path $7zipBinWinArchDest -Force | Out-Null
+        Copy-Item -Path (Join-Path $nodeModulesSrc "7zip-bin\index.js") -Destination $7zipBinDest -Force -ErrorAction Stop
+        Copy-Item -Path (Join-Path $nodeModulesSrc "7zip-bin\package.json") -Destination $7zipBinDest -Force -ErrorAction Stop
+        Copy-Item -Path (Join-Path $nodeModulesSrc "7zip-bin\win\$arch\*") -Destination $7zipBinWinArchDest -Recurse -Force -ErrorAction Stop
+
+        # Copy required modules and dependencies -- all OSes
+        $allOsModules = @(
+            "puppeteer-core",
+            "@puppeteer\browsers",
+            "chromium-bidi",
+            "debug",
+            "devtools-protocol",
+            "ms",
+            "typed-query-selector",
+            "webdriver-bidi-protocol",
+            "ws"
+        )
+
+        foreach ($mod in $allOsModules) {
+            $modDest = Join-Path $nodeModulesDest $mod
+            New-Item -ItemType Directory -Path $modDest -Force | Out-Null
+            Copy-Item -Path (Join-Path $nodeModulesSrc "$mod\*") -Destination $modDest -Recurse -Force -ErrorAction Stop
+        }
+
+        Write-Host "Successfully copied node_modules dependencies"
+
         # Determine which startup to use -- dev viewer or production
         if ($Dev -eq "Y") {
           Remove-Item $electronDestPath\electronStartup.js

--- a/windows/install/makeInstallElectronite.ps1
+++ b/windows/install/makeInstallElectronite.ps1
@@ -172,6 +172,12 @@ try {
             "typed-query-selector",
             "webdriver-bidi-protocol",
             "ws"
+            "semver"
+            "proxy-agent"
+            "lru-cache"
+            "agent-base"
+            "proxy-from-env"
+            "progress"
         )
 
         foreach ($mod in $allOsModules) {


### PR DESCRIPTION
## This PR

### Includes a manual packaging process
As this repo is not built by a packager, we are manually placing puppeteer required packages and dependencies in the installation files.
- While the development environment uses `package.json` / `package-lock.json` from this repo, the build process does not, so testing of installed results will become critical if packages are upgraded, added, or changed.
  - (In such future cases, consider that a installed package can be built locally, which can be useful for pre-testing prior to merging a client change into its `dev` branch.)
- This is not a shotgun approach, rather is adding a precision list only of dependencies that cause an actual error if they do not exist, _which varies by OS_. This keeps payloads to a minimum. See the dependencies included in the following diffs.
  - linux/install/makeInstallElectronite.bsh
  - macos/install/makeInstallElectronite.sh
  - windows/install/makeInstallElectronite.ps1
- To experience this in development environment it will be necessary to re-run the `build_viewer` script (which sets up the new `electronDevStartup.js` as its `electronStartup.js` with the API's needed by the client(s) leveraging puppeteer) and uses `node_modules` in your local repo

### Supports:
- Checking if the designated version of Firefox (FF) already exists in `~/pankosmia/_assets/`
- User-prompted download of FF
  - Custom handling of Windows download to eliminate its otherwise forced user-manned installation process
  - Relies on `@puppeteer/browsers` for Linux and MacOS

### Changing the FF Version
- The required version of FF will be easy to change when that time comes: `const FIREFOX_VERSION = '149.0.2';`
