### PR TITLE
Add optional version suffix and timestamp

### DIFF
--- a/.github/workflows/buildMaster.yml
+++ b/.github/workflows/buildMaster.yml
@@ -17,7 +17,6 @@ on:
           - all of qa
           - all of dev
         default: all of main
-
       os:
         description: 'OS'
         required: true
@@ -28,7 +27,6 @@ on:
           - linux
           - macos
         default: all
-
       log_level:
         description: 'Log level'
         required: true
@@ -39,6 +37,10 @@ on:
           - debug
           - 'off'
         default: critical
+      artifact_suffix:
+        description: 'Artifact name identifier (optional)'
+        required: false
+        default: ""
 
 # set run name from input so the run appears with that name (no API call needed)
 run-name: >-
@@ -48,15 +50,29 @@ run-name: >-
   - log=${{ inputs.log_level }}
 
 jobs:
-  build:
+  setup:
     runs-on: ubuntu-latest
+    outputs:
+      timestamp:       ${{ steps.stamp.outputs.timestamp }}
+      artifact_suffix: ${{ inputs.artifact_suffix }}
     steps:
+      - name: Sanitize artifact_suffix
+        id: sanitize
+        env:
+          ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix }}
+        run: |
+          CLEAN=$(printf '%s' "$ARTIFACT_SUFFIX" | tr -cd 'A-Za-z0-9._-')
+          CLEAN=${CLEAN:0:50}
+          echo "artifact_suffix=$CLEAN" >> "$GITHUB_OUTPUT"
+      - id: stamp
+        run: echo "timestamp=$(date -u +'%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
       - run: |
           echo "Branches is ${{ inputs.branches }}"
           echo "OS is ${{ inputs.os }}"
           echo "Log level is ${{ inputs.log_level }}"
 
   build-macos-x64:
+    needs: setup
     name: Build on macOS x64 (Intel64)
     if: ${{ inputs.os == 'all' || inputs.os == 'macos' }}
     uses: ./.github/workflows/macos-build-steps.yml
@@ -67,6 +83,7 @@ jobs:
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
 
   build-macos-arm64:
+    needs: setup
     name: Build on macOS ARM64 (Apple Silicon)
     if: ${{ inputs.os == 'all' || inputs.os == 'macos' }}
     uses: ./.github/workflows/macos-build-steps.yml
@@ -77,6 +94,7 @@ jobs:
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
 
   build-windows-x64:
+    needs: setup
     name: Build on Windows x64
     if: ${{ inputs.os == 'all' || inputs.os == 'windows' }}
     uses: ./.github/workflows/windows-build-steps.yml
@@ -86,6 +104,7 @@ jobs:
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
 
   build-windows-arm64:
+    needs: setup
     name: Build on Windows arm64
     if: ${{ inputs.os == 'all' || inputs.os == 'windows' }}
     uses: ./.github/workflows/windows-build-steps.yml
@@ -95,6 +114,7 @@ jobs:
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
 
   build-linux-x64:
+    needs: setup
     name: Build on Linux x64
     if: ${{ inputs.os == 'all' || inputs.os == 'linux' }}
     uses: ./.github/workflows/linux-build-steps.yml
@@ -104,6 +124,7 @@ jobs:
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
 
   build-linux-arm64:
+    needs: setup
     name: Build on Linux arm64
     if: ${{ inputs.os == 'all' || inputs.os == 'linux' }}
     uses: ./.github/workflows/linux-build-steps.yml
@@ -151,28 +172,3 @@ jobs:
           check "linux-arm64"        "${{ needs.build-linux-arm64.result }}"
 
           echo "Selected builds completed successfully"
-
-# TODO
-#  create-universal-binary:
-#    needs: [build-macos-x64, build-macos-arm64]
-#    runs-on: macos-latest
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v3
-#
-#      - name: Download Intel artifact
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: ${{ needs.build-macos-x64.outputs.zip-name }}
-#          path: ./downloads/intel
-#
-#      - name: Download ARM artifact
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: ${{ needs.build-macos-arm64.outputs.zip-name }}
-#          path: ./downloads/arm
-#
-#      - name: Create universal binary
-#        run: |
-#          # Your script to combine the Intel and ARM builds
-#          echo "Creating universal binary from Intel and ARM artifacts"

--- a/.github/workflows/buildMaster.yml
+++ b/.github/workflows/buildMaster.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       timestamp:       ${{ steps.stamp.outputs.timestamp }}
-      artifact_suffix: ${{ inputs.artifact_suffix }}
+      artifact_suffix: ${{ steps.sanitize.outputs.artifact_suffix }}
     steps:
       - name: Sanitize artifact_suffix
         id: sanitize
@@ -81,6 +81,8 @@ jobs:
       delay_seconds: 1
       log_level: ${{ inputs.log_level }}
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
+      timestamp:       ${{ needs.setup.outputs.timestamp }}
+      artifact_suffix: ${{ needs.setup.outputs.artifact_suffix }}
 
   build-macos-arm64:
     needs: setup
@@ -92,6 +94,8 @@ jobs:
       delay_seconds: 600
       log_level: ${{ inputs.log_level }}
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
+      timestamp:       ${{ needs.setup.outputs.timestamp }}
+      artifact_suffix: ${{ needs.setup.outputs.artifact_suffix }}
 
   build-windows-x64:
     needs: setup
@@ -102,6 +106,8 @@ jobs:
       runner: windows-2025
       log_level: ${{ inputs.log_level }}
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
+      timestamp:       ${{ needs.setup.outputs.timestamp }}
+      artifact_suffix: ${{ needs.setup.outputs.artifact_suffix }}
 
   build-windows-arm64:
     needs: setup
@@ -112,6 +118,8 @@ jobs:
       runner: windows-11-arm
       log_level: ${{ inputs.log_level }}
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
+      timestamp:       ${{ needs.setup.outputs.timestamp }}
+      artifact_suffix: ${{ needs.setup.outputs.artifact_suffix }}
 
   build-linux-x64:
     needs: setup
@@ -122,6 +130,8 @@ jobs:
       runner: ubuntu-22.04
       log_level: ${{ inputs.log_level }}
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
+      timestamp:       ${{ needs.setup.outputs.timestamp }}
+      artifact_suffix: ${{ needs.setup.outputs.artifact_suffix }}
 
   build-linux-arm64:
     needs: setup
@@ -132,6 +142,8 @@ jobs:
       runner: ubuntu-22.04-arm
       log_level: ${{ inputs.log_level }}
       branches: ${{ inputs.branches == 'all of main' && 'main' || inputs.branches == 'all of qa' && 'qa' || 'dev' }}
+      timestamp:       ${{ needs.setup.outputs.timestamp }}
+      artifact_suffix: ${{ needs.setup.outputs.artifact_suffix }}
 
   finalize:
     needs: [build-macos-x64, build-macos-arm64, build-windows-x64, build-windows-arm64, build-linux-x64, build-linux-arm64]

--- a/.github/workflows/linux-build-steps.yml
+++ b/.github/workflows/linux-build-steps.yml
@@ -79,6 +79,13 @@ jobs:
         with:
           node-version: '20.19.5'
 
+      # Add suffix to version
+      - name: Run gha_ver_suffix.bsh
+        working-directory: ./linux/install
+        run: |
+          chmod +x ./gha_ver_suffix.bsh
+          ./gha_ver_suffix.bsh "${{ inputs.artifact_suffix != '' && format('{0}-{1}', inputs.artifact_suffix, inputs.timestamp) || inputs.timestamp }}"
+
       # Install the repository
       - name: Install this repo
         run: npm ci

--- a/.github/workflows/linux-build-steps.yml
+++ b/.github/workflows/linux-build-steps.yml
@@ -13,6 +13,15 @@ on:
       log_level:
         required: true
         type: string
+      timestamp:
+        description: 'Build-order timestamp computed once in the setup job'
+        required: true
+        type: string
+      artifact_suffix:
+        description: 'Artifact name identifier (optional)'
+        required: false
+        type: string
+        default: ''
     outputs:
       tgz-name:
         description: "Name of the generated TGZ file"

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -14,6 +14,15 @@ on:
       log_level:
         required: true
         type: string
+      timestamp:
+        description: 'Build-order timestamp computed once in the setup job'
+        required: true
+        type: string
+      artifact_suffix:
+        description: 'Artifact name identifier (optional)'
+        required: false
+        type: string
+        default: ''
       delay_seconds:
         description: 'Number of seconds to delay before starting the build'
         required: false

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -102,6 +102,13 @@ jobs:
         with:
           node-version: '20.19.5'
 
+      # Add suffix to version
+      - name: Run gha_ver_suffix.zsh
+        working-directory: ./macos/install
+        run: |
+          chmod +x ./gha_ver_suffix.zsh
+          ./gha_ver_suffix.zsh "${{ inputs.artifact_suffix != '' && format('{0}-{1}', inputs.artifact_suffix, inputs.timestamp) || inputs.timestamp }}"
+
       # Install the repository
       - name: Install this repo
         run: npm ci

--- a/.github/workflows/windows-build-steps.yml
+++ b/.github/workflows/windows-build-steps.yml
@@ -13,6 +13,15 @@ on:
       log_level:
         required: true
         type: string
+      timestamp:
+        description: 'Build-order timestamp computed once in the setup job'
+        required: true
+        type: string
+      artifact_suffix:
+        description: 'Artifact name identifier (optional)'
+        required: false
+        type: string
+        default: ''
     outputs:
       zip-name:
         description: "Name of the generated ZIP file"
@@ -73,6 +82,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.19.5'
+
+      # Add suffix to version
+      - name: Run gha_ver_suffix.bat
+        working-directory: .\windows\install
+        run: .\gha_ver_suffix.bat "${{ inputs.artifact_suffix != '' && format('{0}-{1}', inputs.artifact_suffix, inputs.timestamp) || inputs.timestamp }}"
 
       # Set APP_VERSION from app_config.env
       - name: Extract APP_VERSION from app_config.env

--- a/app_config.env
+++ b/app_config.env
@@ -26,8 +26,7 @@ CLIENT9=core-contenthandler_bcv
 CLIENT10=core-contenthandler_version_manager
 CLIENT11=core-contenthandler-generic
 CLIENT12=core-contenthandler_t_core
-CLIENT13=core-contenthandler_audio_translation
-CLIENT14=core-client_pdf_publisher
+CLIENT13=core-client_pdf_publisher
 
 # Theme -- Customize /globalBuildResources/favicon.ico and /globalBuildResources/theme.json directly.
 

--- a/linux/install/gha_ver_suffix.bsh
+++ b/linux/install/gha_ver_suffix.bsh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+echo
+
+# This file is used by GHA to send a version suffix argument.
+# The argument will be appended to the end of APP_VERSION in app_config.env
+
+if [ -n "$1" ]; then
+    # Rewrite the APP_VERSION in app_config.env
+    configFile="../../app_config.env"
+
+    echo "  Using version suffix \"$1\""
+    sed -i '/^APP_VERSION/ s/$/'"$1"'/' "$configFile"
+fi

--- a/linux/install/gha_ver_suffix.bsh
+++ b/linux/install/gha_ver_suffix.bsh
@@ -13,5 +13,5 @@ if [ -n "$1" ]; then
     configFile="../../app_config.env"
 
     echo "  Using version suffix \"$1\""
-    sed -i '/^APP_VERSION/ s/$/'"$1"'/' "$configFile"
+    sed -i '/^APP_VERSION/ s/$/'-"$1"'/' "$configFile"
 fi

--- a/macos/install/gha_ver_suffix.zsh
+++ b/macos/install/gha_ver_suffix.zsh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+echo
+
+# This file is used by GHA to send a version suffix argument.
+# The argument will be appended to the end of APP_VERSION in app_config.env
+
+if [ -n "$1" ]; then
+  # Rewrite the APP_VERSION in app_config.env
+  configFile="../../app_config.env"
+
+  echo "  Using version suffix \"$1\""
+  sed -i '' '/^APP_VERSION/ s/$/'"$1"'/' "$configFile"
+fi

--- a/macos/install/gha_ver_suffix.zsh
+++ b/macos/install/gha_ver_suffix.zsh
@@ -13,5 +13,5 @@ if [ -n "$1" ]; then
   configFile="../../app_config.env"
 
   echo "  Using version suffix \"$1\""
-  sed -i '' '/^APP_VERSION/ s/$/'"$1"'/' "$configFile"
+  sed -i '' '/^APP_VERSION/ s/$/'-"$1"'/' "$configFile"
 fi

--- a/windows/install/gha_ver_suffix.bat
+++ b/windows/install/gha_ver_suffix.bat
@@ -1,0 +1,31 @@
+@echo off
+REM This file is used by GHA to send a version suffix argument.
+REM The argument will be appended to the end of APP_VERSION in app_config.env
+
+IF "%~1"=="" (
+  goto :continue
+) ELSE (
+  set "suffix=%~1"
+)
+
+REM Rewrite the APP_VERSION in app_config.env
+set "configFile=..\..\app_config.env"
+
+setlocal enabledelayedexpansion
+echo.
+echo   Using version suffix "%suffix%"
+
+set "configTmp=..\..\app_config.env.tmp"
+(for /f "usebackq tokens=*" %%a in ("!configFile!") do (
+  set "line=%%a"
+  echo !line! | findstr /C:"APP_VERSION" >nul
+  if !errorlevel! equ 0 (
+    echo !line!-%suffix%
+  ) else (
+    echo(!line!
+  )
+)) > "!configTmp!"
+move /y "!configTmp!" "!configFile!" >nul
+endlocal
+
+:continue


### PR DESCRIPTION
## This PR:
<img width="316" height="333" alt="image" src="https://github.com/user-attachments/assets/8bbd5c64-45d1-49f3-9fc9-a11c23ff09ca" align="right"/>1. Adds optional workflow input for an "Artifact name identifier" (screenshot to the right), which if entered will be appended to the version number as a simple way to include it in the filename for all artifacts.
2. Also appends the same GitHub Actions workflow start timestamp to the version number -- the same timestamp for all OSes -- also as a simple way to include it in the filename for all artifacts.

**Note:** _This PR does not accomplish either of the above for builds that are run locally, rather leaves them as they were._
<br />
<br />
<br />
<br />
### When "Artifact name identifier" is left blank, artifacts will look like this:
(except that most apps have much shorter app names than this example...)
<img width="485" height="791" alt="Screenshot 2026-07-20 212951-list" src="https://github.com/user-attachments/assets/395cc1ca-0b44-4888-b470-bff81a216cef" />

### Pithekos nightly builds
There is a separate [branch waiting at that repo](https://github.com/pankosmia/desktop-app-pithekos/blob/run/specify_nightly_for_filenames/.github/workflows/nightlyAllOfDev.yml#L26) that adds 1 line to specify its identifier. But first:
1. We accept this PR.
2. Sync by script
3. Then we'll make the branch above a PR at the pithekos repo

The result will both include "nightly" in the filename and on the About page.  The resulting About pages will look like this:

| OS | Example |
|---|---|
| Win | <img width="379" height="50" alt="Screenshot 2026-07-20 212632-win" src="https://github.com/user-attachments/assets/9ad6cd59-f34d-479c-883b-c590db4f584c" /> |
| Linux | <img width="372" height="61" alt="Screenshot 2026-07-20 212458" src="https://github.com/user-attachments/assets/d58aec49-570b-44f7-bdcb-cd1c53768c49" /> |
| Mac | <img width="368" height="59" alt="Screenshot 2026-07-20 at 9 31 10 PM" src="https://github.com/user-attachments/assets/b03afc2b-e4a2-4386-92e1-f00cc12243f3" /> |

### Ordering your own test artifacts
To [order your own](https://github.com/pankosmia/desktop-app-template/actions/workflows/buildMaster.yml) test artifacts at this repo, set "Use workflow from" to "run/suffix_and_timestamp" in the dropdown.
<img width="345" height="176" alt="image" src="https://github.com/user-attachments/assets/2add732c-281d-47e1-95f3-89aacbff3f7b" />

