### PR TITLE
Client uuids

### DIFF
--- a/linux/scripts/build.js
+++ b/linux/scripts/build.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fse = require('fs-extra');
 const copyDir = require('copy-dir');
+const crypto = require('crypto');
 require('@dotenvx/dotenvx').config({path: ['../../app_config.env'], quiet: true});
 
 // Locations
@@ -100,6 +101,11 @@ for (const libClientSrc of spec['libClients'].map(s => path.resolve(s))) {
     const clientDestParent = path.join(BUILD_DIR, "lib", "clients", clientSrcLeaf);
     // - mkdir
     fse.mkdirSync(clientDestParent);
+    // - storage_id.json
+    fs.writeFileSync(
+        path.join(clientDestParent, 'storage_id.json'),
+        JSON.stringify({ id: crypto.randomUUID() })
+    );
     // - package.json
     fse.copySync(
         path.join(libClientSrc, "package.json"),

--- a/linux/scripts/build.js
+++ b/linux/scripts/build.js
@@ -102,7 +102,7 @@ for (const libClientSrc of spec['libClients'].map(s => path.resolve(s))) {
     // - mkdir
     fse.mkdirSync(clientDestParent);
     // - storage_id.json
-    fs.writeFileSync(
+    fse.writeFileSync(
         path.join(clientDestParent, 'storage_id.json'),
         JSON.stringify({ id: crypto.randomUUID() })
     );

--- a/local_server/Cargo.toml
+++ b/local_server/Cargo.toml
@@ -3,7 +3,7 @@ name = "local_server"
 version = "0.1.0"
 edition = "2021"
 [dependencies]
-pankosmia_web = "=0.16.20"
+pankosmia_web = "=0.18.2"
 rocket = { version = "0.5.1", features = ["json"] }
 serde_json = "1.0.132"
 tokio = "1.43.0"

--- a/macos/scripts/build.js
+++ b/macos/scripts/build.js
@@ -123,7 +123,7 @@ for (const libClientSrc of spec['libClients'].map(s => path.resolve(s))) {
     // - mkdir
     fse.mkdirSync(clientDestParent);
     // - storage_id.json
-    fs.writeFileSync(
+    fse.writeFileSync(
         path.join(clientDestParent, 'storage_id.json'),
         JSON.stringify({ id: crypto.randomUUID() })
     );

--- a/macos/scripts/build.js
+++ b/macos/scripts/build.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fse = require('fs-extra');
 const copyDir = require('copy-dir');
+const crypto = require('crypto');
 require('@dotenvx/dotenvx').config({path: ['../../app_config.env'], quiet: true});
 
 // Locations
@@ -121,6 +122,11 @@ for (const libClientSrc of spec['libClients'].map(s => path.resolve(s))) {
     const clientDestParent = path.join(BUILD_DIR, "lib", "clients", clientSrcLeaf);
     // - mkdir
     fse.mkdirSync(clientDestParent);
+    // - storage_id.json
+    fs.writeFileSync(
+        path.join(clientDestParent, 'storage_id.json'),
+        JSON.stringify({ id: crypto.randomUUID() })
+    );
     // - package.json
     fse.copySync(
         path.join(libClientSrc, "package.json"),

--- a/windows/scripts/build.js
+++ b/windows/scripts/build.js
@@ -2,6 +2,7 @@ const path = require('path');
 const fse = require('fs-extra');
 const fs = require('fs');
 const copyDir = require('copy-dir');
+const crypto = require('crypto');
 require('@dotenvx/dotenvx').config({path: ['../../app_config.env'], quiet: true});
 
 // Locations
@@ -111,6 +112,11 @@ for (const libClientSrc of spec['libClients'].map(s => path.resolve(s))) {
     const clientDestParent = path.join(BUILD_DIR, "lib", "clients", clientSrcLeaf);
     // - mkdir
     fse.mkdirSync(clientDestParent);
+    // - storage_id.json
+    fs.writeFileSync(
+        path.join(clientDestParent, 'storage_id.json'),
+        JSON.stringify({ id: crypto.randomUUID() })
+    );
     // - package.json
     fse.copySync(
         path.join(libClientSrc, "package.json"),


### PR DESCRIPTION
- Uses node.js's built-in crypto.randomUUID() function.
- Code additions are identical for each OS, except that win is setup with const `fs` where mac and linux use const 'fse`.
  -  It was quite a simple addition one worked out.
- This generates a `storage_id.json` in each `<os>/build/client/<repo-name>/` directory on each use of `run.<bsh|zsh|bat>` and on each app build.
  - Content of a sample generated file is: `{"id":"c4a0104a-4e83-4acc-9d42-e001430dd586"}`
- `storage_id.json` has been confirmed as present in:
 - Win local dev, CLI artifact, and exe artifact as confirmed by x64 install
 - Linux local dev, CLI artifact, and deb artifact as confirmed by x64 install
 - Mac CLI artifact (ergo, it _should_ be in zipped pkg artifacts, as the CLI artifact is used)

Here are [artifacts built on this branch](https://github.com/pankosmia/desktop-app-template/actions/runs/30316745860).

*Should* be good to go.

