### PR TITLE
Starting internet state config

### DIFF
--- a/app_config.env
+++ b/app_config.env
@@ -1,6 +1,7 @@
 APP_NAME='Pankosmia Desktop App Template'
 APP_SHORT_NAME=template
 APP_VERSION=0.5.0-rc2-test1
+START_OFFLINE=true
 
 # Assets -- Repeat the sequential trio # patterns to add more assets.
 ASSET1=resource-core

--- a/linux/scripts/app_setup.bsh
+++ b/linux/scripts/app_setup.bsh
@@ -8,7 +8,6 @@ echo "     *   - /windows/buildResources/setup/app_setup.json *"
 echo "     *   - /macos/buildResources/setup/app_setup.json   *"
 echo "     *   - /linux/buildResources/setup/app_setup.json   *"
 echo "     *   - /buildSpec.json                              *"
-echo "     *   - /globalBuildResources/product.json           *"
 echo "     *                                                  *"
 echo "     * /globalBuildResources/i18nPatch.json:            *"
 echo "     *   - Created if it does not exist, otherwise      *"
@@ -124,14 +123,6 @@ done
 echo "  ]">> $clients
 echo "}">> $clients
 
-echo "{"> $product
-echo "  \"name\": \"$APP_NAME\",">> $product
-echo "  \"short_name\": \"$APP_SHORT_NAME\",">> $product
-echo "  \"version\": \"$APP_VERSION\",">> $product
-echo "  \"datetime\": \"$(date '+%d %b %Y %H:%M:%S UTC%:z')\",">> $product
-echo "  \"homepage\": \"$HOMEPAGE\"">> $product
-echo "}">> $product
-
 echo "  ],">> $spec
 echo "  \"favIcon\": \"../../globalBuildResources/favicon.ico\",">> $spec
 echo "  \"theme\": \"../../globalBuildResources/theme.json\",">> $spec
@@ -142,7 +133,6 @@ echo "}">> $spec
 echo
 echo "/buildSpec.json generated/rebuilt/replaced"
 echo "/globalBuildResources/i18nPatch.json generated/rebuilt/replaced"
-echo "/globalBuildResources/product.json generated/rebuilt/replaced"
 echo "/linux/buildResources/setup/app_setup.json generated/rebuilt/replaced"
 echo
 echo "Copying /linux/buildResources/setup/app_setup.json to /windows/buildResources/setup/"

--- a/linux/scripts/build.js
+++ b/linux/scripts/build.js
@@ -1,8 +1,49 @@
 const path = require('path');
-const fse = require('fs-extra');
+const fs = require('fs-extra');
 const copyDir = require('copy-dir');
 const crypto = require('crypto');
-require('@dotenvx/dotenvx').config({path: ['../../app_config.env'], quiet: true});
+require('@dotenvx/dotenvx').config({
+  path: ['../../app_config.env'],
+  quiet: true
+});
+
+function formatProductDatetime() {
+  const now = new Date();
+
+  const pad = (n) => String(n).padStart(2, '0');
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+  const day = pad(now.getDate());
+  const month = months[now.getMonth()];
+  const year = now.getFullYear();
+  const hours = pad(now.getHours());
+  const minutes = pad(now.getMinutes());
+  const seconds = pad(now.getSeconds());
+
+  const offsetMinutes = -now.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? '+' : '-';
+  const offsetHours = pad(Math.floor(Math.abs(offsetMinutes) / 60));
+  const offsetMins = pad(Math.abs(offsetMinutes) % 60);
+
+  return `${day} ${month} ${year} ${hours}:${minutes}:${seconds} UTC${sign}${offsetHours}:${offsetMins}`;
+}
+
+function writeProductJson() {
+  const productPath = path.resolve(__dirname, '../../globalBuildResources/product.json');
+
+  const product = {
+    name: (process.env.APP_NAME || '').replace(/^'|'$/g, ''),
+    short_name: process.env.APP_SHORT_NAME || '',
+    version: process.env.APP_VERSION || '',
+    datetime: formatProductDatetime(),
+    homepage: process.env.HOMEPAGE || '',
+    start_offline: process.env.START_OFFLINE === 'true' ? true : false,
+  };
+
+  fs.writeFileSync(productPath, JSON.stringify(product, null, 2) + '\n', 'utf8');
+
+  return productPath;
+}
 
 // Locations
 const BUILD_DIR = path.resolve('../build');
@@ -13,52 +54,52 @@ const SPEC_PATH = path.resolve('../../buildSpec.json');
 const LINUX_BUILD_RESOURCES = path.resolve("../buildResources");
 const REPO_ROOT = path.resolve("../../");
 // Delete build dir if it exists
-if (fse.existsSync(BUILD_DIR)) {
-    fse.rmSync(BUILD_DIR, {recursive: true, force: true});
+if (fs.existsSync(BUILD_DIR)) {
+    fs.rmSync(BUILD_DIR, {recursive: true, force: true});
 }
 // Make build directory
-fse.mkdirSync(BUILD_DIR);
+fs.mkdirSync(BUILD_DIR);
 // Load spec and extract some reusable information
-const spec = fse.readJsonSync(path.resolve(SPEC_PATH));
+const spec = fs.readJsonSync(path.resolve(SPEC_PATH));
 const APP_NAME = spec['app']['name']
 const FILE_APP_NAME = spec['app']['name'].toLowerCase().replace(/ /g, "-");
 const APP_VERSION = process.env.APP_VERSION;
 // Copy Rocket config
-fse.copySync(
+fs.copySync(
     path.join(REPO_ROOT, "Rocket.toml"),
     path.join(BUILD_DIR, "Rocket.toml")
 );
 // Copy and rename launcher script
-fse.copySync(
+fs.copySync(
     path.join(LINUX_BUILD_RESOURCES, "appLauncher.bsh"),
     path.join(BUILD_DIR, FILE_APP_NAME)
 );
 // Copy port checker
 const FIND_FREE_PORT = "find_free_port.sh";
-fse.copySync(
+fs.copySync(
     path.join(LINUX_BUILD_RESOURCES, FIND_FREE_PORT),
     path.join(BUILD_DIR, FIND_FREE_PORT)
 );
 // Copy and customize README
-const readMe = fse.readFileSync(path.join(LINUX_BUILD_RESOURCES, "README.txt"))
+const readMe = fs.readFileSync(path.join(LINUX_BUILD_RESOURCES, "README.txt"))
     .toString()
     .replace(/%%APP_NAME%%/g, APP_NAME)
     .replace(/%%APP_VERSION%%/g, APP_VERSION);
-fse.writeFileSync(
+fs.writeFileSync(
     path.join(BUILD_DIR, "README.txt"),
     readMe
 );
 // Make bin directory
-fse.mkdirSync(path.join(BUILD_DIR, "bin"));
+fs.mkdirSync(path.join(BUILD_DIR, "bin"));
 // Copy bin
 const BIN_SRC = path.resolve(spec['bin']['src']);
-fse.copySync(
+fs.copySync(
     BIN_SRC,
     path.join(BUILD_DIR, "bin", "server.bin")
 );
 // Make lib directory
 const libDirPath = path.join(BUILD_DIR, "lib");
-fse.mkdirSync(libDirPath);
+fs.mkdirSync(libDirPath);
 // Copy lib directories
 for (
     const libSpec of spec['lib']
@@ -79,9 +120,9 @@ for (
 }
 // Patch i18n
 const builtI18nPath = path.join(BUILD_DIR, "lib", "templates", "i18n.json");
-const i18nJson = fse.readJsonSync(builtI18nPath);
+const i18nJson = fs.readJsonSync(builtI18nPath);
 const i18nPatchPath = path.resolve("../../globalBuildResources/i18nPatch.json");
-const patchJson = fse.readJsonSync(i18nPatchPath);
+const patchJson = fs.readJsonSync(i18nPatchPath);
 for ([level1, level1Values] of Object.entries(patchJson)) {
     for ([level2, level2Values] of Object.entries(level1Values)) {
         for ([level3, payload] of Object.entries(level2Values)) {
@@ -92,27 +133,27 @@ for ([level1, level1Values] of Object.entries(patchJson)) {
         }
     }
 }
-fse.writeJsonSync(builtI18nPath, i18nJson);
+fs.writeJsonSync(builtI18nPath, i18nJson);
 // Make lib/clients
-fse.mkdirSync(path.join(BUILD_DIR, "lib", "clients"));
+fs.mkdirSync(path.join(BUILD_DIR, "lib", "clients"));
 // Copy clients and, optionally, favicon:
 for (const libClientSrc of spec['libClients'].map(s => path.resolve(s))) {
     const clientSrcLeaf = libClientSrc.split("/").reverse()[0];
     const clientDestParent = path.join(BUILD_DIR, "lib", "clients", clientSrcLeaf);
     // - mkdir
-    fse.mkdirSync(clientDestParent);
+    fs.mkdirSync(clientDestParent);
     // - storage_id.json
-    fse.writeFileSync(
+    fs.writeFileSync(
         path.join(clientDestParent, 'storage_id.json'),
         JSON.stringify({ id: crypto.randomUUID() })
     );
     // - package.json
-    fse.copySync(
+    fs.copySync(
         path.join(libClientSrc, "package.json"),
         path.join(clientDestParent, "package.json")
     );
     // - pankosmia-metadata.json
-    fse.copySync(
+    fs.copySync(
         path.join(libClientSrc, "pankosmia_metadata.json"),
         path.join(clientDestParent, "pankosmia_metadata.json")
     );
@@ -124,7 +165,7 @@ for (const libClientSrc of spec['libClients'].map(s => path.resolve(s))) {
     );
     // - maybe favicon
     if (spec.favIcon) {
-        fse.copySync(
+        fs.copySync(
             path.resolve(spec.favIcon),
             path.join(clientDestParent, "build", "favicon.ico")
         );
@@ -132,35 +173,37 @@ for (const libClientSrc of spec['libClients'].map(s => path.resolve(s))) {
 }
 // Theme
 if (spec.theme) {
-    fse.copySync(
+    fs.copySync(
         path.resolve(spec.theme),
         path.join(BUILD_DIR, "lib", "app_resources", "themes", "default.json")
     );
 }
 // Product
+const generatedProductPath = writeProductJson();
+
 if (spec.product) {
-    fse.copySync(
-        path.resolve(spec.product),
-        path.join(BUILD_DIR, "lib", "app_resources", "product", "product.json")
-    );
+  fs.copySync(
+    generatedProductPath,
+    path.join(BUILD_DIR, "lib", "app_resources", "product", "product.json")
+  );
 }
 // i18n Overrides
 const I18N_OVERRIDES = "../../globalBuildResources/i18n-overrides.json";
 if (I18N_OVERRIDES) {
-    fse.copySync(
+    fs.copySync(
         path.resolve(I18N_OVERRIDES),
         path.join(BUILD_DIR, "lib", "app_resources", "product", "i18n-overrides.json")
     );
 }
 // client_config
 if (spec.client_config) {
-    fse.copySync(
+    fs.copySync(
         path.resolve(spec.client_config),
         path.join(BUILD_DIR, "lib", "app_resources", "product", "client_config.json")
     );
 }
 // Product Resources
-fse.copySync(
+fs.copySync(
     path.resolve("../../globalBuildResources/product_resources"),
     path.join(BUILD_DIR, "lib", "app_resources", "product", "product_resources"),
     { recursive: true }

--- a/macos/scripts/app_setup.zsh
+++ b/macos/scripts/app_setup.zsh
@@ -8,7 +8,6 @@ echo "     *   - /windows/buildResources/setup/app_setup.json *"
 echo "     *   - /macos/buildResources/setup/app_setup.json   *"
 echo "     *   - /linux/buildResources/setup/app_setup.json   *"
 echo "     *   - /buildSpec.json                              *"
-echo "     *   - /globalBuildResources/product.json           *"
 echo "     *                                                  *"
 echo "     * /globalBuildResources/i18nPatch.json:            *"
 echo "     *   - Created if it does not exist, otherwise      *"
@@ -124,14 +123,6 @@ done
 echo "  ]">> $clients
 echo "}">> $clients
 
-echo "{"> $product
-echo "  \"name\": \"$APP_NAME\",">> $product
-echo "  \"short_name\": \"$APP_SHORT_NAME\",">> $product
-echo "  \"version\": \"$APP_VERSION\",">> $product
-echo "  \"datetime\": \"$(date '+%d %b %Y %H:%M:%S UTC%:z')\",">> $product
-echo "  \"homepage\": \"$HOMEPAGE\"">> $product
-echo "}">> $product
-
 echo "  ],">> $spec
 echo "  \"favIcon\": \"../../globalBuildResources/favicon.ico\",">> $spec
 echo "  \"theme\": \"../../globalBuildResources/theme.json\",">> $spec
@@ -142,7 +133,6 @@ echo "}">> $spec
 echo
 echo "/buildSpec.json generated/rebuilt/replaced"
 echo "/globalBuildResources/i18nPatch.json generated/rebuilt/replaced"
-echo "/globalBuildResources/product.json generated/rebuilt/replaced"
 echo "/macos/buildResources/setup/app_setup.json generated/rebuilt/replaced"
 echo
 echo "Copying /macos/buildResources/setup/app_setup.json to /windows/buildResources/setup/"

--- a/macos/scripts/build.js
+++ b/macos/scripts/build.js
@@ -1,8 +1,49 @@
 const path = require('path');
-const fse = require('fs-extra');
+const fs = require('fs-extra');
 const copyDir = require('copy-dir');
 const crypto = require('crypto');
-require('@dotenvx/dotenvx').config({path: ['../../app_config.env'], quiet: true});
+require('@dotenvx/dotenvx').config({
+  path: ['../../app_config.env'],
+  quiet: true
+});
+
+function formatProductDatetime() {
+  const now = new Date();
+
+  const pad = (n) => String(n).padStart(2, '0');
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+  const day = pad(now.getDate());
+  const month = months[now.getMonth()];
+  const year = now.getFullYear();
+  const hours = pad(now.getHours());
+  const minutes = pad(now.getMinutes());
+  const seconds = pad(now.getSeconds());
+
+  const offsetMinutes = -now.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? '+' : '-';
+  const offsetHours = pad(Math.floor(Math.abs(offsetMinutes) / 60));
+  const offsetMins = pad(Math.abs(offsetMinutes) % 60);
+
+  return `${day} ${month} ${year} ${hours}:${minutes}:${seconds} UTC${sign}${offsetHours}:${offsetMins}`;
+}
+
+function writeProductJson() {
+  const productPath = path.resolve(__dirname, '../../globalBuildResources/product.json');
+
+  const product = {
+    name: (process.env.APP_NAME || '').replace(/^'|'$/g, ''),
+    short_name: process.env.APP_SHORT_NAME || '',
+    version: process.env.APP_VERSION || '',
+    datetime: formatProductDatetime(),
+    homepage: process.env.HOMEPAGE || '',
+    start_offline: process.env.START_OFFLINE === 'true' ? true : false,
+  };
+
+  fs.writeFileSync(productPath, JSON.stringify(product, null, 2) + '\n', 'utf8');
+
+  return productPath;
+}
 
 // Locations
 const BUILD_DIR = path.resolve('../build');
@@ -13,73 +54,73 @@ const SPEC_PATH = path.resolve('../../buildSpec.json');
 const MACOS_BUILD_RESOURCES = path.resolve("../buildResources");
 const REPO_ROOT = path.resolve("../../");
 // Delete build dir if it exists
-if (fse.existsSync(BUILD_DIR)) {
-    fse.rmSync(BUILD_DIR, {recursive: true, force: true});
+if (fs.existsSync(BUILD_DIR)) {
+    fs.rmSync(BUILD_DIR, {recursive: true, force: true});
 }
 // Make build directory
-fse.mkdirSync(BUILD_DIR);
+fs.mkdirSync(BUILD_DIR);
 // Load spec and extract some reusable information
-const spec = fse.readJsonSync(path.resolve(SPEC_PATH));
+const spec = fs.readJsonSync(path.resolve(SPEC_PATH));
 const APP_NAME = spec['app']['name']
 const FILE_APP_NAME = spec['app']['name'].toLowerCase().replace(/ /g, "-");
 const APP_EXT = "zsh";
 const APP_VERSION = process.env.APP_VERSION;
 // Copy Rocket config
-fse.copySync(
+fs.copySync(
     path.join(REPO_ROOT, "Rocket.toml"),
     path.join(BUILD_DIR, "Rocket.toml")
 );
 // Copy and rename launcher script
-fse.copySync(
+fs.copySync(
     path.join(MACOS_BUILD_RESOURCES, "appLauncher.zsh"),
     path.join(BUILD_DIR, FILE_APP_NAME + "." + APP_EXT)
 );
 // Copy and customize sh launcher for pkg
-const appLauncherSh = fse.readFileSync(path.join(MACOS_BUILD_RESOURCES, "appLauncher.sh"))
+const appLauncherSh = fs.readFileSync(path.join(MACOS_BUILD_RESOURCES, "appLauncher.sh"))
     .toString()
     .replace(/%%APP_NAME%%/g, APP_NAME)
     .replace(/%%FILE_APP_NAME%%/g, FILE_APP_NAME);
-fse.writeFileSync(
+fs.writeFileSync(
     path.join(BUILD_DIR, "appLauncher.sh"),
     appLauncherSh
 );
 // Copy and customize sh post-install script for pkg
-const postInstallSh = fse.readFileSync(path.join(MACOS_BUILD_RESOURCES, "post_install_script.sh"))
+const postInstallSh = fs.readFileSync(path.join(MACOS_BUILD_RESOURCES, "post_install_script.sh"))
     .toString()
     .replace(/%%APP_NAME%%/g, APP_NAME)
     .replace(/%%FILE_APP_NAME%%/g, FILE_APP_NAME);
-fse.writeFileSync(
+fs.writeFileSync(
     path.join(BUILD_DIR, "post_install_script.sh"),
     postInstallSh
 );
 // Copy port checker
 const FIND_FREE_PORT = "find_free_port.sh";
-fse.copySync(
+fs.copySync(
     path.join(MACOS_BUILD_RESOURCES, FIND_FREE_PORT),
     path.join(BUILD_DIR, FIND_FREE_PORT)
 );
 // Copy and customize README
-const readMe = fse.readFileSync(path.join(MACOS_BUILD_RESOURCES, "README.txt"))
+const readMe = fs.readFileSync(path.join(MACOS_BUILD_RESOURCES, "README.txt"))
     .toString()
     .replace(/%%APP_NAME%%/g, APP_NAME)
     .replace(/%%FILE_APP_NAME%%/g, FILE_APP_NAME)
     .replace(/%%APP_EXT%%/g, APP_EXT)
     .replace(/%%APP_VERSION%%/g, APP_VERSION);
-fse.writeFileSync(
+fs.writeFileSync(
     path.join(BUILD_DIR, "README.txt"),
     readMe
 );
 // Make bin directory
-fse.mkdirSync(path.join(BUILD_DIR, "bin"));
+fs.mkdirSync(path.join(BUILD_DIR, "bin"));
 // Copy bin
 const BIN_SRC = path.resolve(spec['bin']['src']);
-fse.copySync(
+fs.copySync(
     BIN_SRC,
     path.join(BUILD_DIR, "bin", "server.bin")
 );
 // Make lib directory
 const libDirPath = path.join(BUILD_DIR, "lib");
-fse.mkdirSync(libDirPath);
+fs.mkdirSync(libDirPath);
 // Copy lib directories
 for (
     const libSpec of spec['lib']
@@ -100,9 +141,9 @@ for (
 }
 // Patch i18n
 const builtI18nPath = path.join(BUILD_DIR, "lib", "templates", "i18n.json");
-const i18nJson = fse.readJsonSync(builtI18nPath);
+const i18nJson = fs.readJsonSync(builtI18nPath);
 const i18nPatchPath = path.resolve("../../globalBuildResources/i18nPatch.json");
-const patchJson = fse.readJsonSync(i18nPatchPath);
+const patchJson = fs.readJsonSync(i18nPatchPath);
 for ([level1, level1Values] of Object.entries(patchJson)) {
     for ([level2, level2Values] of Object.entries(level1Values)) {
         for ([level3, payload] of Object.entries(level2Values)) {
@@ -113,27 +154,27 @@ for ([level1, level1Values] of Object.entries(patchJson)) {
         }
     }
 }
-fse.writeJsonSync(builtI18nPath, i18nJson);
+fs.writeJsonSync(builtI18nPath, i18nJson);
 // Make lib/clients
-fse.mkdirSync(path.join(BUILD_DIR, "lib", "clients"));
+fs.mkdirSync(path.join(BUILD_DIR, "lib", "clients"));
 // Copy clients and, optionally, favicon:
 for (const libClientSrc of spec['libClients'].map(s => path.resolve(s))) {
     const clientSrcLeaf = libClientSrc.split("/").reverse()[0];
     const clientDestParent = path.join(BUILD_DIR, "lib", "clients", clientSrcLeaf);
     // - mkdir
-    fse.mkdirSync(clientDestParent);
+    fs.mkdirSync(clientDestParent);
     // - storage_id.json
-    fse.writeFileSync(
+    fs.writeFileSync(
         path.join(clientDestParent, 'storage_id.json'),
         JSON.stringify({ id: crypto.randomUUID() })
     );
     // - package.json
-    fse.copySync(
+    fs.copySync(
         path.join(libClientSrc, "package.json"),
         path.join(clientDestParent, "package.json")
     );
     // - pankosmia-metadata.json
-    fse.copySync(
+    fs.copySync(
         path.join(libClientSrc, "pankosmia_metadata.json"),
         path.join(clientDestParent, "pankosmia_metadata.json")
     );
@@ -145,7 +186,7 @@ for (const libClientSrc of spec['libClients'].map(s => path.resolve(s))) {
     );
     // - maybe favicon
     if (spec.favIcon) {
-        fse.copySync(
+        fs.copySync(
             path.resolve(spec.favIcon),
             path.join(clientDestParent, "build", "favicon.ico")
         );
@@ -153,35 +194,37 @@ for (const libClientSrc of spec['libClients'].map(s => path.resolve(s))) {
 }
 // Theme
 if (spec.theme) {
-    fse.copySync(
+    fs.copySync(
         path.resolve(spec.theme),
         path.join(BUILD_DIR, "lib", "app_resources", "themes", "default.json")
     );
 }
 // Product
+const generatedProductPath = writeProductJson();
+
 if (spec.product) {
-    fse.copySync(
-        path.resolve(spec.product),
-        path.join(BUILD_DIR, "lib", "app_resources", "product", "product.json")
-    );
+  fse.copySync(
+    generatedProductPath,
+    path.join(BUILD_DIR, "lib", "app_resources", "product", "product.json")
+  );
 }
 // i18n Overrides
 const I18N_OVERRIDES = "../../globalBuildResources/i18n-overrides.json";
 if (I18N_OVERRIDES) {
-    fse.copySync(
+    fs.copySync(
         path.resolve(I18N_OVERRIDES),
         path.join(BUILD_DIR, "lib", "app_resources", "product", "i18n-overrides.json")
     );
 }
 // client_config
 if (spec.client_config) {
-    fse.copySync(
+    fs.copySync(
         path.resolve(spec.client_config),
         path.join(BUILD_DIR, "lib", "app_resources", "product", "client_config.json")
     );
 }
 // Product Resources
-fse.copySync(
+fs.copySync(
     path.resolve("../../globalBuildResources/product_resources"),
     path.join(BUILD_DIR, "lib", "app_resources", "product", "product_resources"),
     { recursive: true }

--- a/windows/scripts/app_setup.bat
+++ b/windows/scripts/app_setup.bat
@@ -8,7 +8,6 @@ echo      *   - \windows\buildResources\setup\app_setup.json *
 echo      *   - \macos\buildResources\setup\app_setup.json   *
 echo      *   - \linux\buildResources\setup\app_setup.json   *
 echo      *   - \buildSpec.json                              *
-echo      *   - \globalBuildResources\product.json           *
 echo      *                                                  *
 echo      * \globalBuildResources\i18nPatch.json:            *
 echo      *   - Created if it does not exist, otherwise      *
@@ -171,7 +170,6 @@ echo }>> %spec%
 echo.
 echo \buildSpec.json generated/rebuilt/replaced
 echo \globalBuildResources\i18nPatch.json generated/rebuilt/replaced
-echo \globalBuildResources\product.json generated/rebuilt/replaced
 echo \windows\buildResources\setup\app_setup.json generated/rebuilt/replaced
 echo.
 echo Copying \windows\buildResources\setup\app_setup.json to \linux\buildResources\setup\

--- a/windows/scripts/app_setup.bat
+++ b/windows/scripts/app_setup.bat
@@ -161,14 +161,6 @@ if %tzH% LSS 10 set "tzH=0%tzH%"
 if %tzM% LSS 10 set "tzM=0%tzM%"
 set tz=%sign%%tzH%:%tzM%
 
-echo {>%product%
-echo   "name": "%APP_NAME:'=%",>> %product%
-echo   "short_name": "%APP_SHORT_NAME%",>> %product%
-echo   "version": "%APP_VERSION%",>> %product%
-echo   "datetime": "%dd% %mname% %yyyy% %hh%:%min%:%ss% UTC%tz%",>> %product%
-echo   "homepage": "%HOMEPAGE%">> %product%
-echo }>> %product%
-
 echo   ],>> %spec%
 echo   "favIcon": "../../globalBuildResources/favicon.ico",>> %spec%
 echo   "theme": "../../globalBuildResources/theme.json",>> %spec%

--- a/windows/scripts/build.js
+++ b/windows/scripts/build.js
@@ -3,7 +3,48 @@ const fse = require('fs-extra');
 const fs = require('fs');
 const copyDir = require('copy-dir');
 const crypto = require('crypto');
-require('@dotenvx/dotenvx').config({path: ['../../app_config.env'], quiet: true});
+require('@dotenvx/dotenvx').config({
+  path: ['../../app_config.env'],
+  quiet: true
+});
+
+function formatProductDatetime() {
+  const now = new Date();
+
+  const pad = (n) => String(n).padStart(2, '0');
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+  const day = pad(now.getDate());
+  const month = months[now.getMonth()];
+  const year = now.getFullYear();
+  const hours = pad(now.getHours());
+  const minutes = pad(now.getMinutes());
+  const seconds = pad(now.getSeconds());
+
+  const offsetMinutes = -now.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? '+' : '-';
+  const offsetHours = pad(Math.floor(Math.abs(offsetMinutes) / 60));
+  const offsetMins = pad(Math.abs(offsetMinutes) % 60);
+
+  return `${day} ${month} ${year} ${hours}:${minutes}:${seconds} UTC${sign}${offsetHours}:${offsetMins}`;
+}
+
+function writeProductJson() {
+  const productPath = path.resolve(__dirname, '../../globalBuildResources/product.json');
+
+  const product = {
+    name: (process.env.APP_NAME || '').replace(/^'|'$/g, ''),
+    short_name: process.env.APP_SHORT_NAME || '',
+    version: process.env.APP_VERSION || '',
+    datetime: formatProductDatetime(),
+    homepage: process.env.HOMEPAGE || '',
+    start_offline: process.env.START_OFFLINE === 'true' ? true : false,
+  };
+
+  fs.writeFileSync(productPath, JSON.stringify(product, null, 2) + '\n', 'utf8');
+
+  return productPath;
+}
 
 // Locations
 const BUILD_DIR = path.resolve('../build');
@@ -151,11 +192,13 @@ if (spec.theme) {
 }
 
 // Product
+const generatedProductPath = writeProductJson();
+
 if (spec.product) {
-    fse.copySync(
-        path.resolve(spec.product),
-        path.join(BUILD_DIR, "lib", "app_resources", "product", "product.json")
-    );
+  fse.copySync(
+    generatedProductPath,
+    path.join(BUILD_DIR, "lib", "app_resources", "product", "product.json")
+  );
 }
 
 // i18n Overrides
@@ -201,4 +244,3 @@ const fixWindowsUtf8 = (srcFilePath, destFilePath) => {
 
 const PAGED_JS = path.resolve(spec['lib'][0]['src'] + '/pdf/paged.polyfill.js');
 fixWindowsUtf8(PAGED_JS, BUILD_DIR + '/lib/' + spec['lib'][0]['targetName'] + '/pdf/paged.polyfill.js')
-


### PR DESCRIPTION
This PR:
- Adds `START_OFFLINE=true` to `app_config.env` with `START_OFFLINE=false` as the other implied valid state
- Uses that to add either `"start_offline": true` or `"start_offline": false` to `product.json` 
- Moves writing of `product.json` out of `app_setup.<bsh|zsh|bat>`
  - toward future elimination of the `app_setup.<bsh|zsh|bat>` script
    - Bonus: Uses the exact same code for this is in `<os>/scripts/build.js` for all os wheras the prior approach differed (future: share common js code instead of repeating 3x).
  - Additional bonus:  Local development environment will get a new `datetime` on every `run.<bsh|zsh|bat>`, so no longer containing misleading info from when `app_setup.<bsh|zsh|bat>` was last run.
- Closes #92

Checking:
- The CLI version of [this GHA run](https://github.com/pankosmia/desktop-app-template/actions/runs/31128221419) (queued at the time of typing this) will have CLI zips for each OS in which the resulting product.json can be opened and review in `lib/app_resources/product/product.json`