### PR TITLE
Get storage_id.json from client repos

### DIFF
--- a/linux/scripts/build.js
+++ b/linux/scripts/build.js
@@ -143,11 +143,11 @@ for (const libClientSrc of spec['libClients'].map(s => path.resolve(s))) {
     // - mkdir
     fs.mkdirSync(clientDestParent);
     // - storage_id.json
-    fs.writeFileSync(
-        path.join(clientDestParent, 'storage_id.json'),
-        JSON.stringify({ id: crypto.randomUUID() }, null, 2),
-        'utf8'
-    );
+    const uuidSrc = path.join(libClientSrc, "storage_id.json");
+    const uuidDest = path.join(clientDestParent, "storage_id.json");
+    if (fs.existsSync(uuidSrc)) {
+      fs.copySync(uuidSrc, uuidDest);
+    }
     // - package.json
     fs.copySync(
         path.join(libClientSrc, "package.json"),

--- a/linux/scripts/build.js
+++ b/linux/scripts/build.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const fs = require('fs-extra');
 const copyDir = require('copy-dir');
-const crypto = require('crypto');
 require('@dotenvx/dotenvx').config({
   path: ['../../app_config.env'],
   quiet: true

--- a/macos/scripts/build.js
+++ b/macos/scripts/build.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const fs = require('fs-extra');
 const copyDir = require('copy-dir');
-const crypto = require('crypto');
 require('@dotenvx/dotenvx').config({
   path: ['../../app_config.env'],
   quiet: true

--- a/macos/scripts/build.js
+++ b/macos/scripts/build.js
@@ -164,11 +164,11 @@ for (const libClientSrc of spec['libClients'].map(s => path.resolve(s))) {
     // - mkdir
     fs.mkdirSync(clientDestParent);
     // - storage_id.json
-    fs.writeFileSync(
-        path.join(clientDestParent, 'storage_id.json'),
-        JSON.stringify({ id: crypto.randomUUID() }, null, 2),
-        'utf8'
-    );
+    const uuidSrc = path.join(libClientSrc, "storage_id.json");
+    const uuidDest = path.join(clientDestParent, "storage_id.json");
+    if (fs.existsSync(uuidSrc)) {
+      fs.copySync(uuidSrc, uuidDest);
+    }
     // - package.json
     fs.copySync(
         path.join(libClientSrc, "package.json"),

--- a/windows/scripts/build.js
+++ b/windows/scripts/build.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const fs = require('fs-extra');
 const copyDir = require('copy-dir');
-const crypto = require('crypto');
 require('@dotenvx/dotenvx').config({
   path: ['../../app_config.env'],
   quiet: true

--- a/windows/scripts/build.js
+++ b/windows/scripts/build.js
@@ -153,11 +153,11 @@ for (const libClientSrc of spec['libClients'].map(s => path.resolve(s))) {
     // - mkdir
     fs.mkdirSync(clientDestParent);
     // - storage_id.json
-    fs.writeFileSync(
-        path.join(clientDestParent, 'storage_id.json'),
-        JSON.stringify({ id: crypto.randomUUID() }, null, 2),
-        'utf8'
-    );
+    const uuidSrc = path.join(libClientSrc, "storage_id.json");
+    const uuidDest = path.join(clientDestParent, "storage_id.json");
+    if (fs.existsSync(uuidSrc)) {
+      fs.copySync(uuidSrc, uuidDest);
+    }
     // - package.json
     fs.copySync(
         path.join(libClientSrc, "package.json"),


### PR DESCRIPTION
This mirrors our `package.json` cp from client repo on build.js, with the addition of a test to confirm the file exists before copying. This allows for the possibility that some branches of some repos may not necessarily have this file yet during its implementation (e.g., might not necessarily yet exist on `main`).