### PR TITLE
confirm server is running before launching window

### DIFF
--- a/buildResources/electron/electronStartup.js
+++ b/buildResources/electron/electronStartup.js
@@ -19,7 +19,6 @@
  * - Electron.js
  * - A compatible backend server binary (server.bin for macOS/Linux or server.exe for Windows)
  * - The first available port starting at 19119 will be used by the backend server
- * - For macOS/Linux: lsof command must be available for port checking
  * - Environment variable APP_NAME must be set for proper application naming
  */
 
@@ -73,18 +72,12 @@ async function getPort() {
   if (env.ROCKET_PORT && env.ROCKET_PORT.trim() !== '') {
     return Number(env.ROCKET_PORT);
   }
-  return await findFreePort(19119);
+  try {
+    return await findFreePort(19119);
+  } catch {
+    return 19119;   // matches Rocket.toml fallback
+  }
 }
-
-getPort()
-  .then(port => {
-    console.log('Using port ', port);
-    if (env.ROCKET_PORT === undefined) env.ROCKET_PORT = port;
-  })
-  .catch(err => {
-    console.error('Failed to obtain port:', err);
-    app.quit?.();
-  });
 
 let serverProcess = null;
 app.name = '${APP_NAME}';
@@ -251,17 +244,6 @@ function getBundledFfmpegExecutablePath() {
 async function isFfmpegInstalled() {
   const ffmpegPath = await getAvailableFfmpegPath();
   return !!ffmpegPath;
-}
-
-// Function to check if server is running (on port)
-function isServerRunning() {
-  try {
-    // macOS & Linux: use lsof; Windows would require a different approach
-    execSync(`lsof -i:${env.ROCKET_PORT} | grep LISTEN`, { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 // Helper to get the Firefox executable path (used by generate-pdf)
@@ -690,28 +672,64 @@ function delay(ms) {
 const MAC_SERVER_PATH = './bin/server.bin';
 const WIN_SERVER_PATH = './bin/server.exe';
 
+async function waitForServerReady(port, opts = {}) {
+  const {
+    overallTimeoutMs = 20000,
+    perRequestTimeoutMs = 2000,
+    intervalMs = 300,
+  } = opts;
+
+  const url = `http://127.0.0.1:${port}/api/version`;
+  const deadline = Date.now() + overallTimeoutMs;
+  let lastError = null;
+
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, {
+        signal: AbortSignal.timeout(perRequestTimeoutMs),
+        // Avoid any caching surprises during startup probing:
+        cache: 'no-store',
+      });
+
+      if (res.ok) return; // server is ready
+
+      // A response but not 2xx (e.g. 404/500 while booting) → keep trying.
+      lastError = new Error(`Unexpected status ${res.status} from ${url}`);
+    } catch (err) {
+      // ECONNREFUSED, socket reset, DNS, or per-request AbortError → keep trying.
+      lastError = err;
+    }
+
+    // Guard against sleeping when there's not enough time left 
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await delay(Math.min(intervalMs, remaining));
+  }
+
+  throw new Error(
+    `Server did not become ready within ${overallTimeoutMs} ms` +
+    (lastError ? ` (last error: ${lastError.message})` : '')
+  );
+}
+
 function startServer() {
-  if (!isServerRunning()) {
-    const serverPath = process.platform === 'win32' ? WIN_SERVER_PATH : MAC_SERVER_PATH;
-    const workingDir =  path.join(__dirname, '..');
+  const serverPath = process.platform === 'win32' ? WIN_SERVER_PATH : MAC_SERVER_PATH;
+  const workingDir =  path.join(__dirname, '..');
 
   console.log('resourcesDir is ' + env.APP_RESOURCES_DIR);
 
-    // console.log('startServer() - workingDir is ' + workingDir);
-    // console.log('startServer() - resourcesDir is ' + resourcesDir);
-    // console.log('startServer() - env is ', env);
-    
-    serverProcess = spawn(serverPath, [], {
-      stdio: 'ignore',
-      detached: true,
-      env: env,
-      cwd: workingDir
-    });
-    serverProcess.unref();
-    // console.log('startServer() - Server started at ' + path.join(workingDir, serverPath));
-  } else {
-    // console.log(startServer() - 'Server already running.');
-  }
+  // console.log('startServer() - workingDir is ' + workingDir);
+  // console.log('startServer() - resourcesDir is ' + resourcesDir);
+  // console.log('startServer() - env is ', env);
+  
+  serverProcess = spawn(serverPath, [], {
+    stdio: 'ignore',
+    detached: true,
+    env: env,
+    cwd: workingDir
+  });
+  serverProcess.unref();
+  // console.log('startServer() - Server started at ' + path.join(workingDir, serverPath));
 }
 
 function stopServer() {
@@ -728,7 +746,7 @@ function stopServer() {
     // Optionally: kill whatever is listening on port
     try {
       console.log('stopServer() - Trying to stop server forcefully.');
-      execSync(`lsof -t -i:${env.ROCKET_PORT} | xargs kill -9`);
+      execSync(`lsof -t -i:${env.ROCKET_PORT} | xargs kill -9`);  // but lsof does not exist in Windows
       console.log('stopServer() - Server stopped forcefully.');
     } catch {
       // ignore if nothing is running
@@ -754,79 +772,117 @@ function installAudioCaptureHandlers(ses) {
 }
 
 function createWindow() {
-    delay(500).then(() => {
-        // console.log('createWindow() - after delay');
-        const win = new BrowserWindow({
-            width: 1024,
-            height: 768,
-            minWidth: 900,
-            minHeight: 600,
-            autoHideMenuBar: false,
-            show: false,  // Don't show until ready to maximize
-            icon: path.join(__dirname, 'favicon.png'),
-            webPreferences: {
-                preload: path.join(__dirname, 'preload.js'),
-                nodeIntegration: false, //default is also false. True leads to console error.
-                contextIsolation: true, //default is also true. What is the impact of changing this to false?
-                enableRemoteModule: false, //default is also false. What is the impact of changing this to true?
-                sandbox: false, // default is also false
-              }
-        });
+    // console.log('createWindow() - after delay');
+    const win = new BrowserWindow({
+        width: 1024,
+        height: 768,
+        minWidth: 900,
+        minHeight: 600,
+        autoHideMenuBar: false,
+        show: false,  // Don't show until ready to maximize
+        icon: path.join(__dirname, 'favicon.png'),
+        webPreferences: {
+            preload: path.join(__dirname, 'preload.js'),
+            nodeIntegration: false, //default is also false. True leads to console error.
+            contextIsolation: true, //default is also true. What is the impact of changing this to false?
+            enableRemoteModule: false, //default is also false. What is the impact of changing this to true?
+            sandbox: false, // default is also false
+          }
+    });
 
-        installAudioCaptureHandlers(win.webContents.session);
+    installAudioCaptureHandlers(win.webContents.session);
 
-        win.once('ready-to-show', () => {
-            win.maximize();
-            win.show();
-            setTimeout(() => {
-              InitializeMenu();
-              win.show();
-              win.maximize();
-            }, 300);
-        });
+    win.once('ready-to-show', () => {
+        win.maximize();
+        win.show();
+        setTimeout(() => {
+          InitializeMenu();
+          win.show();
+          win.maximize();
+        }, 300);
+    });
 
-        // Show a dialog to the user to confirm the close
-        win.on('close', (event) => {
-            if (!canClose) {
-                event.preventDefault();
-                dialog.showMessageBox(win, {
-                    type: 'question',
-                    title: 'Unsaved changes',
-                    message: 'You have unsaved changes. Are you sure you want to close the application?',
-                    buttons: ['Yes', 'No'],
-                }).then((result) => {
-                    if (result.response === 0) {
-                        canClose = true;
-                        win.close();
-                    }
-                });
-            }
-        });
+    // Show a dialog to the user to confirm the close
+    win.on('close', (event) => {
+        if (!canClose) {
+            event.preventDefault();
+            dialog.showMessageBox(win, {
+                type: 'question',
+                title: 'Unsaved changes',
+                message: 'You have unsaved changes. Are you sure you want to close the application?',
+                buttons: ['Yes', 'No'],
+            }).then((result) => {
+                if (result.response === 0) {
+                    canClose = true;
+                    win.close();
+                }
+            });
+        }
+    });
 
-        // Show a dialog to the user switch pages
-        win.webContents.on('will-navigate', async (event, url) => {
-            if (!canClose) {
-                event.preventDefault();
-                dialog.showMessageBox(win, {
-                    title: 'Unsaved changes',
-                    type: 'question',
-                    message: 'You have unsaved changes. Are you sure you want to leave this page?',
-                    buttons: ['Yes', 'No'],
-                }).then((result) => {
-                    if (result.response === 0) {
-                        canClose = true;
-                        win.loadURL(url);
-                    }
-                });
-            }
-        });
+    // Show a dialog to the user switch pages
+    win.webContents.on('will-navigate', async (event, url) => {
+        if (!canClose) {
+            event.preventDefault();
+            dialog.showMessageBox(win, {
+                title: 'Unsaved changes',
+                type: 'question',
+                message: 'You have unsaved changes. Are you sure you want to leave this page?',
+                buttons: ['Yes', 'No'],
+            }).then((result) => {
+                if (result.response === 0) {
+                    canClose = true;
+                    win.loadURL(url);
+                }
+            });
+        }
+    });
 
-        win.loadURL(`http://127.0.0.1:${env.ROCKET_PORT}`);
-    })
-
+    win.loadURL(`http://127.0.0.1:${env.ROCKET_PORT}`);
 }
 
-app.whenReady().then(() => {
+async function attemptStartup(port) {
+  if (START_SERVER) startServer();   // (re)spawn only in server-managed mode
+  // TODO: prod Retry must stopServer() before respawning — see deferred stopServer()/taskkill work
+  await waitForServerReady(port, {
+    overallTimeoutMs: 20000,
+    perRequestTimeoutMs: 2000,
+    intervalMs: 300,
+  });
+}
+
+function showStartupFailure(err, port) {
+  console.error('Server readiness check failed:', err);
+
+  const buttons = START_SERVER ? ['Quit'] : ['Retry', 'Quit'];
+  const retryIndex = START_SERVER ? -1 : 0;
+  const quitIndex = START_SERVER ? 0 : 1;
+
+  const ACT = START_SERVER
+    ? `The backend could not be started. Please quit and try again.`
+    : `Waiting for the server. Start it, then click Retry.`;
+
+  dialog.showMessageBox({
+    type: 'error',
+    title: 'Startup problem',
+    message: 'The application backend did not start.',
+    detail:
+      `We couldn't reach the backend on port ${port}.\n\n` +
+      `${err.message}\n\n` +
+      ACT,
+    buttons,
+    defaultId: START_SERVER ? quitIndex : retryIndex,
+    cancelId: quitIndex,
+  }).then((result) => {
+    if (result.response === retryIndex) {   // only reachable in dev
+      attemptStartup(port).then(createWindow).catch((e) => showStartupFailure(e, port));
+    } else {
+      app.quit();
+    }
+  });
+}
+
+app.whenReady().then(async () => {
   ipcMain.on('setCanClose', handleSetCanClose);
 
   // IPC: Check if Firefox browser engine is already downloaded
@@ -979,13 +1035,30 @@ app.whenReady().then(() => {
       event.sender.send('ffmpeg-download-complete', false, err.message);
     }
   });
+
+  try {
+    const port = await getPort();
+    env.ROCKET_PORT = String(port);
+    console.log('Using port', port);
+  } catch (err) {
+    console.error('Failed to obtain port:', err);
+    dialog.showErrorBox('Startup problem', 'Could not find a free port.');
+    app.quit();
+    return;
+  }
   
   if (START_SERVER) {
     startServer();
   }
-  const DELAY = START_SERVER ? 2000 : 0; // Wait 2 seconds for server to start (adjust as needed)
-  setTimeout(createWindow, DELAY);
+
+  const port = Number(env.ROCKET_PORT);
+
+  // initial attempt
+  attemptStartup(port)
+    .then(createWindow)
+    .catch((err) => showStartupFailure(err, port));
 });
+
 app.on('window-all-closed', () => {
   console.log('window-all-closed() - app quitting');
   // On macOS, apps are expected to stay alive until explicitly quit

--- a/buildResources/electron/electronStartup.js
+++ b/buildResources/electron/electronStartup.js
@@ -772,7 +772,6 @@ function installAudioCaptureHandlers(ses) {
 }
 
 function createWindow() {
-    // console.log('createWindow() - after delay');
     const win = new BrowserWindow({
         width: 1024,
         height: 768,
@@ -842,44 +841,76 @@ function createWindow() {
 }
 
 async function attemptStartup(port) {
-  if (START_SERVER) startServer();   // (re)spawn only in server-managed mode
-  // TODO: prod Retry must stopServer() before respawning — see deferred stopServer()/taskkill work
-  await waitForServerReady(port, {
-    overallTimeoutMs: 20000,
-    perRequestTimeoutMs: 2000,
-    intervalMs: 300,
-  });
+  if (START_SERVER) {
+    startServer();
+  }
+  await waitForServerReady(port);
+}
+
+function humanizeStartupError(err, port) {
+  // Log the raw thing for us; show the friendly thing to the user.
+  console.error('[startup] backend failed to become ready:', err);
+
+  const name = err && err.name;
+  const msg = (err && err.message) || String(err);
+
+  // Our own deadline timeout (from waitForServerReady).
+  if (name === 'TimeoutError' || /timed out|deadline|not ready/i.test(msg)) {
+    return `The app couldn't reach the backend on port ${port} in time. ` +
+           `It may still be starting up, or something is blocking it.`;
+  }
+
+  // Port already taken / bind failure surfaced from spawn.
+  if (/EADDRINUSE/i.test(msg)) {
+    return `Port ${port} is already in use by another program, ` +
+           `so the backend couldn't start.`;
+  }
+
+  // Couldn't even launch the server process.
+  if (/ENOENT/i.test(msg)) {
+    return `The backend program couldn't be found or launched.`;
+  }
+
+  // Connection refused during polling.
+  if (/ECONNREFUSED/i.test(msg)) {
+    return `The backend didn't respond on port ${port}. ` +
+           `It may have stopped or failed to start.`;
+  }
+
+  // Fallback: still readable, no stack trace.
+  return `The backend couldn't be started (${msg}).`;
 }
 
 function showStartupFailure(err, port) {
-  console.error('Server readiness check failed:', err);
+  const friendly = humanizeStartupError(err, port);
 
-  const buttons = START_SERVER ? ['Quit'] : ['Retry', 'Quit'];
-  const retryIndex = START_SERVER ? -1 : 0;
-  const quitIndex = START_SERVER ? 0 : 1;
-
-  const ACT = START_SERVER
-    ? `The backend could not be started. Please quit and try again.`
-    : `Waiting for the server. Start it, then click Retry.`;
-
-  dialog.showMessageBox({
-    type: 'error',
-    title: 'Startup problem',
-    message: 'The application backend did not start.',
-    detail:
-      `We couldn't reach the backend on port ${port}.\n\n` +
-      `${err.message}\n\n` +
-      ACT,
-    buttons,
-    defaultId: START_SERVER ? quitIndex : retryIndex,
-    cancelId: quitIndex,
-  }).then((result) => {
-    if (result.response === retryIndex) {   // only reachable in dev
-      attemptStartup(port).then(createWindow).catch((e) => showStartupFailure(e, port));
+  if (!START_SERVER) {
+    // Development Environment
+    const choice = dialog.showMessageBoxSync({
+      type: 'warning',
+      buttons: ['Retry', 'Quit'],
+      defaultId: 0,
+      message: 'Waiting for the server.',
+      detail: `${friendly}\n\nStart it, then click Retry.`,
+    });
+    if (choice === 0) {
+      attemptStartup(port)
+        .then(createWindow)
+        .catch((e) => showStartupFailure(e, port));
     } else {
       app.quit();
     }
-  });
+  } else {
+    // Production Environment
+    dialog.showMessageBoxSync({
+      type: 'error',
+      buttons: ['Quit'],
+      defaultId: 0,
+      message: 'The backend could not be started.',
+      detail: `${friendly}\n\nPlease quit and try again.`,
+    });
+    app.quit();
+  }
 }
 
 app.whenReady().then(async () => {
@@ -1036,28 +1067,16 @@ app.whenReady().then(async () => {
     }
   });
 
+  const port = await getPort();
+  env.ROCKET_PORT = String(port);
+
   try {
-    const port = await getPort();
-    env.ROCKET_PORT = String(port);
-    console.log('Using port', port);
+    await attemptStartup(port);
+    createWindow();
   } catch (err) {
-    console.error('Failed to obtain port:', err);
-    dialog.showErrorBox('Startup problem', 'Could not find a free port.');
-    app.quit();
-    return;
+    showStartupFailure(err, port);
   }
-  
-  if (START_SERVER) {
-    startServer();
-  }
-
-  const port = Number(env.ROCKET_PORT);
-
-  // initial attempt
-  attemptStartup(port)
-    .then(createWindow)
-    .catch((err) => showStartupFailure(err, port));
-});
+});  
 
 app.on('window-all-closed', () => {
   console.log('window-all-closed() - app quitting');

--- a/buildResources/electron/electronStartup.js
+++ b/buildResources/electron/electronStartup.js
@@ -706,10 +706,12 @@ async function waitForServerReady(port, opts = {}) {
     await delay(Math.min(intervalMs, remaining));
   }
 
-  throw new Error(
-    `Server did not become ready within ${overallTimeoutMs} ms` +
-    (lastError ? ` (last error: ${lastError.message})` : '')
-  );
+    const e = new Error(
+      `Server did not become ready within ${overallTimeoutMs} ms` +
+      (lastError ? ` (last error: ${lastError.message})` : '')
+    );
+    e.code = 'STARTUP_TIMEOUT';   // <-- tag used to write a friendlier production message
+    throw e;
 }
 
 function startServer() {
@@ -848,37 +850,29 @@ async function attemptStartup(port) {
 }
 
 function humanizeStartupError(err, port) {
-  // Log the raw thing for us; show the friendly thing to the user.
   console.error('[startup] backend failed to become ready:', err);
 
-  const name = err && err.name;
   const msg = (err && err.message) || String(err);
 
-  // Our own deadline timeout (from waitForServerReady).
-  if (name === 'TimeoutError' || /timed out|deadline|not ready/i.test(msg)) {
+  if (err && err.code === 'STARTUP_TIMEOUT') {
     return `The app couldn't reach the backend on port ${port} in time. ` +
            `It may still be starting up, or something is blocking it.`;
   }
-
-  // Port already taken / bind failure surfaced from spawn.
   if (/EADDRINUSE/i.test(msg)) {
-    return `Port ${port} is already in use by another program, ` +
-           `so the backend couldn't start.`;
+    return `Port ${port} is already in use by another program, so the backend couldn't start.`;
   }
-
-  // Couldn't even launch the server process.
   if (/ENOENT/i.test(msg)) {
     return `The backend program couldn't be found or launched.`;
   }
-
-  // Connection refused during polling.
   if (/ECONNREFUSED/i.test(msg)) {
-    return `The backend didn't respond on port ${port}. ` +
-           `It may have stopped or failed to start.`;
+    return `The backend didn't respond on port ${port}. It may have stopped or failed to start.`;
   }
+  return `The backend couldn't be started.`;
+}
 
-  // Fallback: still readable, no stack trace.
-  return `The backend couldn't be started (${msg}).`;
+function rawErrorText(err) {
+  if (!err) return String(err);
+  return err.stack || `${err.name || 'Error'}: ${err.message || String(err)}`;
 }
 
 function showStartupFailure(err, port) {
@@ -891,7 +885,10 @@ function showStartupFailure(err, port) {
       buttons: ['Retry', 'Quit'],
       defaultId: 0,
       message: 'Waiting for the server.',
-      detail: `${friendly}\n\nStart it, then click Retry.`,
+      detail:
+        `${friendly}\n\n` +
+        `Start it, then click Retry.\n\n` +
+        `— Developer details —\n${rawErrorText(err)}`,
     });
     if (choice === 0) {
       attemptStartup(port)

--- a/linux/buildResources/launcher.sh
+++ b/linux/buildResources/launcher.sh
@@ -30,6 +30,9 @@ if ! [ -f $PIDFILE ]; then
     pidof server.bin > $PIDFILE
 fi
 
+# Tell electron not to start the server since we just started it.
+export START_SERVER="false"
+
 # Start the client
 source $SETTINGS_FILE
 $APP_DIR/viewer/electron --no-sandbox $APP_DIR/viewer


### PR DESCRIPTION
This PR:
- Polls /api/version to identify when the server has started.
  - (Does *not* evaluate content to confirm the server is ours, though we could if we ever wanted to.)
- Prevents early connections hanging via `AbortController`
- Tolerates connection errors
- Prevents a previously possible port number race condition that doesn't seem to have surfaced yet, perhaps because of our 2 second delay.

## How to test

_(Click on images to zoom.)_
| Development Environment<br />⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀ | Production Environment<br />⠀ |
|---|---|
| <ol><li>Run <code>build_viewer.&lt;bsh&vert;zsh&vert;ps1&gt;</code></li><li>Without a server running, run <code>viewer.&lt;bsh&vert;zsh&vert;bat&gt;</code></li><li>Wait 20s (current timeout setting).</li><li>The following dialog will load:</li></ol> | <ol><li>Install [this branch's artifacts](https://github.com/pankosmia/desktop-app-template/actions/runs/31640661161)</li><li>Hack the install so the server doesn't start to test the error message.<ul><li>_Win/Mac_: Find `electronStartup.js` in the `electron` subdirectory the app launcher loads, then comment out the only instance of `startServer();`</li><li>_Linux_:  Go to `/usr/bin/` and remove the `!` under `# Start the server`.</li><li>The following dialog will load:</li></ul></li></ol> |
| <figure><kbd><img width="518" height="440" alt="image" src="https://github.com/user-attachments/assets/900fc605-161a-4f6f-acb4-6abf3600cd7a" /></kbd><figcaption>MacOS</figcaption></figure> | <figure><kbd><img width="262" height="309" alt="Screenshot 2026-08-13 at 12 14 45 PM" src="https://github.com/user-attachments/assets/3e875630-22de-478e-9c6d-404b8bc4202c" /></kbd><figcaption><br />MacOS</figcaption></figure> |
| <figure><kbd><img width="543" height="381" alt="Windows" src="https://github.com/user-attachments/assets/c74fa53e-933d-43ce-9b57-948c038ea3f6" /></kbd><figcaption>Windows</figcaption></figure> | <figure><kbd><img width="435.2" height="166.4" alt="Windows" src="https://github.com/user-attachments/assets/04ba688a-f0fb-45b0-93c8-553308e46d4c" /></kbd><figcaption><br />Windows</figcaption></figure> |
| <figure><kbd><img width="603" height="393" alt="Linux" src="https://github.com/user-attachments/assets/656ce258-28da-4324-b9f3-283fa200551e" /></kbd><figcaption>Linux</figcaption></figure> | <table><tr><td><figure><kbd><img width="203.33" height="123.67" alt="image" src="https://github.com/user-attachments/assets/2d24d0ef-d836-4bc5-a0df-972124647051" /></kbd><figcaption><br />Linux for now</figcaption></figure></td><td><figure><kbd><img width="203.67" height="66.67" alt="image" src="https://github.com/user-attachments/assets/fcef5d40-20ca-452c-8d03-1526f81b61cd" /></kbd><figcaption><br />Linux (future)</figcaption></figure></td></tr></table> |
| <ul><li>Retry start polling again for up to another 20s.<ul><li>While launch is immediately when the server running, we could change it back to no polling if developers prefer a white-screen when it isn't.</li><li>We could remove the courtesy Retry.</li><li>Developers will most likely quickly figure out what is going and start the server, in which case the viewer will still launch if they beats the timeout setting.</li></ul></li><li>The raw message is in both the console and dialog. The human readable version is just in the dialog.</ul> | <ul><li>If we want "Retry" in Production, the expected behaviour there would be to relaunch the server. But first we should review and update our server stop code in a separate PR.</li><li>The screenshots above shows the timeout error messages. Other possible human readable error messages setup for EADDRINUSE, ENOENT, ECONNREFUSED, and other respectively:<ul><li>Port `${port}` is already in use by another program, so the backend couldn't start.</li><li>The backend program couldn't be found or launched.</li><li>The backend didn't respond on port `${port}`. It may have stopped or failed to start.</li><li>The backend couldn't be started `(${msg})`.</li></ul></li></ul> |

## Testing Status:

| Testing |  Local Development Environment<sup>[1](#footnote)</sup> | [This branch's artifact installs](https://github.com/pankosmia/desktop-app-template/actions/runs/31728250547) | [artifact installs](https://github.com/pankosmia/desktop-app-template/actions/runs/31728250547) with server off |
|---|---|---|---|
| Linux X64 | ✓ | ✓ | ✓ |
| Win X64 | ✓ | ✓ | ✓ |
| Mac Arm64 | ✓ | ✓ | ✓ |

<sup>1</sup> Run `build_viewer.<bsh|ps1|zsh>` then with the server running, run `viewer.<bsh/ps1/zsh>`. And with the server not running and the viewer closed, re-run `viewer.<bsh/ps1/zsh>` and wait 20s for the message to load.