### PR TITLE
Update viewer without download

### DIFF
--- a/.github/workflows/linux-build-steps.yml
+++ b/.github/workflows/linux-build-steps.yml
@@ -126,11 +126,7 @@ jobs:
         working-directory: ./linux/scripts
         run: ./bundle_tgz.bsh -s -g
 
-      - name: Build Electronite viewer
-        working-directory: ./linux/scripts
-        run: ./build_viewer.bsh
-
-      - name: Create .deb installer
+      - name: Create .deb installer (includes Electronite viewer build)
         working-directory: ./linux/scripts
         run: ./bundle_viewer.bsh
 

--- a/.github/workflows/macos-build-steps.yml
+++ b/.github/workflows/macos-build-steps.yml
@@ -190,10 +190,10 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
-      # build electronite installs
+      # build electronite installs (-f = full install)
       - name: Run makeAllInstallsElectronite.sh
         working-directory: ./macos/install
-        run: ./makeAllInstallsElectronite.sh
+        run: ./makeAllInstallsElectronite.sh -f
 
       - name: Get Electronite Installer names
         id: get-electronite-names

--- a/linux/install/makeAllInstallsElectronite.bsh
+++ b/linux/install/makeAllInstallsElectronite.bsh
@@ -20,13 +20,13 @@
 #
 
 # get arguments
-devRun="no" # This is a development viewer run if $1 is -d
+devRun="no"
 
 fullInstall=false
 
 for arg in "$@"; do
     case "$arg" in
-        -d) devRun="-d" ;;
+        -d) devRun="-d" ;; # -d is a development viewer run
         -f) fullInstall=true ;;
     esac
 done

--- a/linux/install/makeAllInstallsElectronite.bsh
+++ b/linux/install/makeAllInstallsElectronite.bsh
@@ -9,8 +9,9 @@
 #   It downloads the required Electron and zip releases, and processes them
 #   into installable packages.
 #
-# Positional Arguments:
-#   $1 -d indicates generation of a development viewer (optional)
+# Flag-style Arguments:
+#   -d indicates generation of a development viewer (optional)
+#   -f indicates a full install including Electronite download/copy (optional)
 #   Note - All URLs and architectures are hardcoded in the script
 #
 # Return Values:
@@ -19,10 +20,19 @@
 #
 
 # get arguments
-devRun="${1:-no}" # This is a development viewer run if $1 is -d
+devRun="no" # This is a development viewer run if $1 is -d
+
+fullInstall=false
+
+for arg in "$@"; do
+    case "$arg" in
+        -d) devRun="-d" ;;
+        -f) fullInstall=true ;;
+    esac
+done
 
 # This script uses the APP_NAME environment variables as defined in app_config.env
-source ../../app_config.env
+source "../../app_config.env"
 
 EMSG="environment variable is not set in makeAllInstallsElectronite.bsh."
 
@@ -46,11 +56,11 @@ FILE_APP_NAME=${FILE_APP_NAME// /-}
 # export environment variables -- available to any subshell; not environment variables!
 echo "FILE_APP_NAME=$FILE_APP_NAME"
 export FILE_APP_NAME="$FILE_APP_NAME"
-echo "APP_NAME=$APP_NAME" 
+echo "APP_NAME=$APP_NAME"
 export APP_NAME="$APP_NAME"
 echo "APP_VERSION=$APP_VERSION"
 export APP_VERSION="$APP_VERSION"
-echo "APP_SHORT_NAME=$APP_SHORT_NAME" 
+echo "APP_SHORT_NAME=$APP_SHORT_NAME"
 export APP_SHORT_NAME="$APP_SHORT_NAME"
 
 ElectronArm64="https://github.com/unfoldingWord/electronite/releases/download/v37.1.0-graphite/electronite-v37.1.0-graphite-linux-arm64.zip"
@@ -74,9 +84,9 @@ for ARCH in "x64" "arm64"; do
         echo "Skipping $ARCH build on $CPU_ARCH machine"
         continue
     fi
-  
-    echo "Building for architecture: $ARCH"
-  
+
+    echo "Architecture: $ARCH"
+
     downloadElectronUrl="$ElectronX64"
     expectedZip="*-x64-cli.zip"
     if [ "$ARCH" = "arm64" ]; then
@@ -84,32 +94,42 @@ for ARCH in "x64" "arm64"; do
         expectedZip="*-arm64-cli.zip"
     fi
 
-    cd ../install # required on local builds runs; no harm in gha
-    ./getElectronRelease.bsh $downloadElectronUrl $ARCH $devRun
+    cd ../install || exit 1  # required on local builds runs; no harm in gha
+    if [ "$fullInstall" = true ]; then
+        ./getElectronRelease.bsh "$downloadElectronUrl" "$ARCH" "$devRun"
 
-    if [ $? -ne 0 ]; then
-        echo "Error: Failed to get Electron release files at downloadElectronUrl - $?"
-        exit 1
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to get Electron release files at $downloadElectronUrl"
+            exit 1
+        fi
+    else
+        echo "Skipping Electron download/release step (not needed)."
     fi
 
     if [[ $devRun =~ ^(-d) ]]; then
-        pkgDir=viewer
+        pkgDir="viewer"
     else
-        pkgDir=temp
+        pkgDir="temp"
     fi
 
-    # Run makeInstallElectronite Shell script
-    echo
-    echo "     *****************************************"
-    echo "     * Running makeInstallElectronite.bsh... *"
-    echo "     * Wait for the prompt.                  *"
-    echo "     *****************************************"
-    echo
-    ./makeInstallElectronite.bsh $ARCH $devRun
+    if [ "$fullInstall" = true ]; then
+        echo
+        echo "     *****************************************"
+        echo "     * Running makeInstallElectronite.bsh... *"
+        echo "     * Wait for the prompt.                  *"
+        echo "     *****************************************"
+        echo
+    fi
+
+    if [ "$fullInstall" = true ]; then
+        ./makeInstallElectronite.bsh "$ARCH" "$devRun" -f
+    else
+        ./makeInstallElectronite.bsh "$ARCH" "$devRun"
+    fi
 
     if ! [[ $devRun =~ ^(-d) ]]; then
         echo "Files at ../../releases/linux/"
-        ls -als ../../releases/linux/
+        ls -als "../../releases/linux/"
     fi
 
     if [ $? -ne 0 ]; then
@@ -122,8 +142,7 @@ echo "Build completed for $CPU_ARCH architecture"
 
 # Remove temporary electronite files from local dev viewer build.
 if [[ $devRun =~ ^(-d) ]]; then
-    rm -rf ../$pkgDir/electron
-    rm -rf ../$pkgDir/electron.*
+    rm -rf "../$pkgDir/electron"
+    rm -rf "../$pkgDir/electron.*"
     echo "Local Dev Electronite Viewer has been successfully built."
 fi
-

--- a/linux/install/makeInstallElectronite.bsh
+++ b/linux/install/makeInstallElectronite.bsh
@@ -11,19 +11,18 @@
 #   1. Creating the installation directory structure
 #   2. Copying application files and resources
 #   3. Setting up proper permissions
-#   4. Configuring application metadata (Info.plist)
+#   4. Configuring application metadata
 #   5. Building the final installer package
 #
 # Requirements:
-#   - APP_VERSION environment variable must be set (e.g., export APP_VERSION="0.2.7")
-#   - Architecture parameter must be provided when running the script (arm64 or x64)
-#   - XCode command line tools must be installed
-#   - brew package manager with shc installed (`brew install shc`)
+#   - APP_VERSION environment variable must be set
+#   - Architecture parameter must be provided when running the script
 #
 # Parameters:
 #   $1 : Architecture type (Required)
 #        Accepted values: arm64, x64
 #   $2 : -d indicates a development run (for building viewer only)
+#   $3 : -f indicates full install including Electronite copy/download setup
 #
 # Returns:
 #   0 : Success
@@ -33,76 +32,83 @@
 #   Creates installer package at: ../releases/linux/<app-name>_installer_<arch>_<version>.pkg
 
 EMSG="environment variable is not set in makeInstallElectronite.bsh."
-# Check if APP_NAME environment variable is set
 if [ -z "$APP_NAME" ]; then
     echo "Error: APP_NAME $EMSG"
     exit 1
 fi
 
-# Check if APP_VERSION environment variable is set
 if [ -z "$APP_VERSION" ]; then
     echo "Error: APP_VERSION $EMSG"
     exit 1
 fi
 
-# Check if FILE_APP_NAME environment variable is set
 if [ -z "$FILE_APP_NAME" ]; then
     echo "Error: FILE_APP_NAME $EMSG"
     exit 1
 fi
-
 # get arguments
 arch="$1"
 devRun="${2:-no}" # This is a development viewer run if $1 is -d
+fullInstall=false
+for arg in "$@"; do
+    case "$arg" in
+        -f) fullInstall=true ;;
+    esac
+done
 
 # Needed for local bundles. Not required in GHA but does no harm.
 if ! [[ $devRun =~ ^(-d) ]]; then
-  rm -f ../releases/linux/${FILE_APP_NAME}-*-linux-${arch}.deb
+    rm -f "../releases/linux/${FILE_APP_NAME}-*-linux-${arch}.deb"
 fi
 
 cd ../build || exit 1
 
-########################################
-# build folder structure for package
-
-# Turn on command echo
-# set -x
-
 if [[ $devRun =~ ^(-d) ]]; then
-        pkgDir=viewer
-    else
-        pkgDir=temp
-    fi
-
-# Needed for local bundles. Not required in GHA but also doesn't hurt anything.
-rm -rf ../$pkgDir/project
+    pkgDir="viewer"
+else
+    pkgDir="temp"
+fi
 
 APP_BASE_DIR="../$pkgDir/project/payload/app"
 
-mkdir -p ${APP_BASE_DIR}
+if [ "$fullInstall" = true ] || ! [[ $devRun =~ ^(-d) ]]; then
+    # Needed for local bundles. Not required in GHA but also doesn't hurt anything.
+    rm -rf "../$pkgDir/project"
+fi
 
-# Rocket config
-cp ../../Rocket.toml ${APP_BASE_DIR}/Rocket.toml
+mkdir -p "$APP_BASE_DIR"
+
+cp "../../Rocket.toml" "${APP_BASE_DIR}/Rocket.toml"
 
 # electron startup
 LAUNCHER_NAME="start-${FILE_APP_NAME}.sh"
-cp ../buildResources/appLauncherElectron.sh ${APP_BASE_DIR}/${LAUNCHER_NAME}
-sed -i.bak "s/\${APP_NAME}/$APP_NAME/g" ${APP_BASE_DIR}/${LAUNCHER_NAME}
+cp "../buildResources/appLauncherElectron.sh" "${APP_BASE_DIR}/${LAUNCHER_NAME}"
+sed -i.bak "s/\${APP_NAME}/$APP_NAME/g" "${APP_BASE_DIR}/${LAUNCHER_NAME}"
 
 # find_free_port.sh, used by electron startup
-cp ../buildResources/find_free_port.sh ${APP_BASE_DIR}/find_free_port.sh
+cp "../buildResources/find_free_port.sh" "${APP_BASE_DIR}/find_free_port.sh"
 
 #remove backup
 rm "${APP_BASE_DIR}/${LAUNCHER_NAME}.bak"
 
 # copy shared electron files
-cp -R ../../buildResources/electron ${APP_BASE_DIR}/
-cp ../../globalBuildResources/favicon*.png ${APP_BASE_DIR}/electron
-echo "Successfully copied electron files"
-
-# Copy required node_modules and dependencies -- all OSes
+ELECTRON_DEST="${APP_BASE_DIR}/electron"
 NODE_MODULES_SRC="../../node_modules"
-NODE_MODULES_DEST="${APP_BASE_DIR}/electron/node_modules"
+NODE_MODULES_DEST="${ELECTRON_DEST}/node_modules"
+
+if [ "$fullInstall" = true ]; then
+    cp -R "../../buildResources/electron" "$APP_BASE_DIR/"
+    echo "Successfully copied shared electron files"
+else
+    echo "Skipping shared electron file copy (not needed)."
+    if [ ! -d "$ELECTRON_DEST" ]; then
+        echo "Error: Electron destination path not found for viewer update: $ELECTRON_DEST"
+        exit 1
+    fi
+fi
+
+cp "../../globalBuildResources/favicon"*.png "$ELECTRON_DEST"
+echo "Copied favicon files"
 
 ALL_OS_MODULES=(
     "puppeteer-core"
@@ -150,15 +156,20 @@ done
 echo "Successfully copied node_modules dependencies"
 
 # Replace all occurrences of ${APP_NAME} and ${APP_VERSION} in startup script
-sed -i.bak "s/\${APP_NAME}/$APP_NAME/g" "${APP_BASE_DIR}/electron/electronStartup.js"  # Replace all occurrences of ${APP_NAME}
-sed -i.bak "s/\${APP_NAME}/$APP_NAME/g" "${APP_BASE_DIR}/electron/package.json"  # Replace all occurrences of ${APP_NAME}
-sed -i.bak "s/\${APP_VERSION}/$APP_VERSION/g" "${APP_BASE_DIR}/electron/package.json"  # Replace all occurrences of ${APP_VERSION}
+sed -i.bak "s/\${APP_NAME}/$APP_NAME/g" "${ELECTRON_DEST}/electronStartup.js"
+sed -i.bak "s/\${APP_NAME}/$APP_NAME/g" "${ELECTRON_DEST}/package.json"
+sed -i.bak "s/\${APP_VERSION}/$APP_VERSION/g" "${ELECTRON_DEST}/package.json"
 
-# now copy architecture specific electron files
-cp -R ../$pkgDir/electron.$arch/* ${APP_BASE_DIR}/electron
+if [ "$fullInstall" = true ]; then
+    # now copy architecture specific electron files
+    cp -R "../$pkgDir/electron.$arch/"* "${ELECTRON_DEST}/"
+    echo "Successfully copied architecture-specific electron files"
+else
+    echo "Skipping architecture-specific electron file copy (not needed)."
+fi
 
 # Check if Electron executable owner is current user
-ELECTRON_OWNER=$(stat --format='%u' ${APP_BASE_DIR}/electron)
+ELECTRON_OWNER=$(stat --format='%u' "$ELECTRON_DEST")
 CURRENT_USER=$(id -u)
 if [ "$ELECTRON_OWNER" != "$CURRENT_USER" ]; then
     echo "Error: Electron executable owner is not current user. Please run: sudo chown -R $(id -u):$(id -g) ../buildResources/electron.$arch/*"
@@ -166,17 +177,16 @@ if [ "$ELECTRON_OWNER" != "$CURRENT_USER" ]; then
 fi
 
 if ! [[ $devRun =~ ^(-d) ]]; then
-  chmod 755 ${APP_BASE_DIR}/linux
-  cp -R ./bin ${APP_BASE_DIR}/
-  echo "copied bin to $APP_BASE_DIR/"
-  chmod 755 ${APP_BASE_DIR}/bin/server.bin
-  chmod 755 ${APP_BASE_DIR}/${LAUNCHER_NAME}
-  chmod 755 ${APP_BASE_DIR}/find_free_port.sh
+    chmod 755 "${APP_BASE_DIR}/linux"
+    cp -R "./bin" "${APP_BASE_DIR}/"
+    echo "copied bin to $APP_BASE_DIR/"
+    chmod 755 "${APP_BASE_DIR}/bin/server.bin"
+    chmod 755 "${APP_BASE_DIR}/${LAUNCHER_NAME}"
+    chmod 755 "${APP_BASE_DIR}/find_free_port.sh"
 
-  cp -R ./lib ${APP_BASE_DIR}/
-  echo "copied lib to $APP_BASE_DIR/"
+    cp -R "./lib" "${APP_BASE_DIR}/"
+    echo "copied lib to $APP_BASE_DIR/"
 fi
 
 # set execute permission on all folders
-find ${APP_BASE_DIR}/ -type d -exec chmod u+x,g+x,o+x {} +
-
+find "${APP_BASE_DIR}/" -type d -exec chmod u+x,g+x,o+x {} +

--- a/linux/install/makeInstallElectronite.bsh
+++ b/linux/install/makeInstallElectronite.bsh
@@ -91,20 +91,17 @@ cp "../buildResources/find_free_port.sh" "${APP_BASE_DIR}/find_free_port.sh"
 #remove backup
 rm "${APP_BASE_DIR}/${LAUNCHER_NAME}.bak"
 
-# copy shared electron files
+# copy app-specific electron files
 ELECTRON_DEST="${APP_BASE_DIR}/electron"
 NODE_MODULES_SRC="../../node_modules"
 NODE_MODULES_DEST="${ELECTRON_DEST}/node_modules"
 
-if [ "$fullInstall" = true ]; then
-    cp -R "../../buildResources/electron" "$APP_BASE_DIR/"
-    echo "Successfully copied shared electron files"
-else
-    echo "Skipping shared electron file copy (not needed)."
-    if [ ! -d "$ELECTRON_DEST" ]; then
-        echo "Error: Electron destination path not found for viewer update: $ELECTRON_DEST"
-        exit 1
-    fi
+cp -R "../../buildResources/electron/." "$ELECTRON_DEST/"
+echo "Successfully copied app-specific electron files"
+
+if [ ! -d "$ELECTRON_DEST" ]; then
+    echo "Error: Electron destination path not found for app-specific electron files: $ELECTRON_DEST"
+    exit 1
 fi
 
 cp "../../globalBuildResources/favicon"*.png "$ELECTRON_DEST"

--- a/linux/scripts/build_viewer.bsh
+++ b/linux/scripts/build_viewer.bsh
@@ -30,7 +30,7 @@ if [ "$fullInstall" != true ]; then
         fullInstall=true
     fi
 else
-    echo "-f flag detected."
+    # -f flag detected.
     echo "A full viewer install will follow, including download of Electronite. Please wait patiently..."
 fi
 

--- a/linux/scripts/build_viewer.bsh
+++ b/linux/scripts/build_viewer.bsh
@@ -1,43 +1,50 @@
 #!/usr/bin/env bash
 
 # Run from pankosmia\[this-repo's-name]\linux\scripts directory by:  ./build_viewer.bsh
+# Or force a full install with: ./build_viewer.bsh -f
 
 ELECTRON_VER="../viewer/project/payload/app/electron/version"
 EXPECTED="37.1.0"
 
-# A full install will also install, or re-install, Electronite.
-fullInstall=false
+FORCE_FULL_INSTALL=false
+if [[ "${1:-}" == "-f" ]]; then
+    FORCE_FULL_INSTALL=true
+fi
 
-if [ -f "$ELECTRON_VER" ]; then
-    content="$(tr -d '\r\n' < "$ELECTRON_VER")"
-    if [ "$content" = "$EXPECTED" ]; then
-        echo "The installed viewer Electronite version is $content, which is correct."
-        echo "No download is needed. Everything else will be updated."
-        fullInstall=false
+# A full install will also install, or re-install, Electronite.
+fullInstall=$FORCE_FULL_INSTALL
+
+if [ "$fullInstall" != true ]; then
+    if [ -f "$ELECTRON_VER" ]; then
+        content="$(tr -d '\r\n' < "$ELECTRON_VER")"
+        if [ "$content" = "$EXPECTED" ]; then
+            echo "The installed viewer Electronite version is $content, which is correct."
+            echo "No download is needed. Everything else will be updated."
+            fullInstall=false
+        else
+            echo "The installed viewer Electronite version is $content, however we are not using $EXPECTED. Please wait for the download and upgrade that will follow..."
+            fullInstall=true
+        fi
     else
-        echo "The installed viewer Electronite version is $content, however we are not using $EXPECTED. Please wait for the download and upgrade that will follow..."
+        echo "A full viewer install will follow, including download of Electronite. Please wait patiently..."
         fullInstall=true
     fi
 else
+    echo "-f flag detected."
     echo "A full viewer install will follow, including download of Electronite. Please wait patiently..."
-    fullInstall=true
 fi
 
 TEMP_DIR="../viewer"
 if [ "$fullInstall" = true ] && [ -d "$TEMP_DIR" ]; then
     echo "Deleting previous viewer build..."
-    echo
     rm -rf "$TEMP_DIR"
 fi
 
 if [ "$fullInstall" = true ]; then
-    echo
-    echo
     echo "********************************************************************"
     echo "\"Getting Electron release\" downloads an approximately 120 MB file."
     echo "Please wait patiently for the download process to complete..."
     echo "********************************************************************"
-    echo
     ../install/makeAllInstallsElectronite.bsh -d -f
 else
     ../install/makeAllInstallsElectronite.bsh -d

--- a/linux/scripts/build_viewer.bsh
+++ b/linux/scripts/build_viewer.bsh
@@ -1,20 +1,44 @@
 #!/usr/bin/env bash
 
-# Run from pankosmia\[this-repo's-name]\linux\scripts directory by:  .\build_viewer.bsh
+# Run from pankosmia\[this-repo's-name]\linux\scripts directory by:  ./build_viewer.bsh
 
-TEMP_DIR=../viewer
-if [ -d $TEMP_DIR ]; then
-    echo "Deleting previous viewer build..."
-    echo
-    rm -rf $TEMP_DIR
+ELECTRON_VER="../viewer/project/payload/app/electron/version"
+EXPECTED="37.1.0"
+
+# A full install will also install, or re-install, Electronite.
+fullInstall=false
+
+if [ -f "$ELECTRON_VER" ]; then
+    content="$(tr -d '\r\n' < "$ELECTRON_VER")"
+    if [ "$content" = "$EXPECTED" ]; then
+        echo "The installed viewer Electronite version is $content, which is correct."
+        echo "No download is needed. Everything else will be updated."
+        fullInstall=false
+    else
+        echo "The installed viewer Electronite version is $content, however we are not using $EXPECTED. Please wait for the download and upgrade that will follow..."
+        fullInstall=true
+    fi
+else
+    echo "A full viewer install will follow, including download of Electronite. Please wait patiently..."
+    fullInstall=true
 fi
 
-echo
-echo
-echo "********************************************************************"
-echo "\"Getting Electron release\" downloads an approximately 120 MB file."
-echo "Please wait patiently for the download process to complete..."
-echo "********************************************************************"
-echo
+TEMP_DIR="../viewer"
+if [ "$fullInstall" = true ] && [ -d "$TEMP_DIR" ]; then
+    echo "Deleting previous viewer build..."
+    echo
+    rm -rf "$TEMP_DIR"
+fi
 
-../install/makeAllInstallsElectronite.bsh -d
+if [ "$fullInstall" = true ]; then
+    echo
+    echo
+    echo "********************************************************************"
+    echo "\"Getting Electron release\" downloads an approximately 120 MB file."
+    echo "Please wait patiently for the download process to complete..."
+    echo "********************************************************************"
+    echo
+    ../install/makeAllInstallsElectronite.bsh -d -f
+else
+    ../install/makeAllInstallsElectronite.bsh -d
+fi

--- a/linux/scripts/bundle_viewer.bsh
+++ b/linux/scripts/bundle_viewer.bsh
@@ -6,6 +6,9 @@ set -u
 source ../../app_config.env
 echo "Building Debian package for $APP_NAME $APP_VERSION"
 
+# Full viewer install, ensuring no stale files are included.
+./build_viewer.bsh -f
+
 # Set variables
 cd ../../
 REPOPATH=$(pwd)

--- a/macos/install/makeAllInstallsElectronite.sh
+++ b/macos/install/makeAllInstallsElectronite.sh
@@ -9,8 +9,9 @@
 #   It downloads the required Electron and zip releases, and processes them
 #   into installable packages.
 #
-# Positional Arguments:
-#   $1 -d indicates generation of a development viewer (optional)
+# Flag-style Arguments:
+#   -d indicates generation of a development viewer (optional)
+#   -f indicates a full install including Electronite download/copy (optional)
 #   Note - All URLs and architectures are hardcoded in the script
 #
 # Return Values:
@@ -19,10 +20,18 @@
 #
 
 # get arguments
-devRun="${1:-no}" # This is a development viewer run if $1 is -d
+devRun="no"
+fullInstall=false
+
+for arg in "$@"; do
+    case "$arg" in
+        -d) devRun="-d" ;; # -d is a development viewer run
+        -f) fullInstall=true ;;
+    esac
+done
 
 # This script uses the APP_NAME environment variables as defined in app_config.env
-source ../../app_config.env
+source "../../app_config.env"
 
 EMSG="environment variable is not set in makeAllInstallsElecrtronite.sh."
 
@@ -46,11 +55,11 @@ FILE_APP_NAME=${FILE_APP_NAME// /-}
 # export environment variables -- available to any subshell; not environment variables!
 echo "FILE_APP_NAME=$FILE_APP_NAME"
 export FILE_APP_NAME="$FILE_APP_NAME"
-echo "APP_NAME=$APP_NAME" 
+echo "APP_NAME=$APP_NAME"
 export APP_NAME="$APP_NAME"
 echo "APP_VERSION=$APP_VERSION"
 export APP_VERSION="$APP_VERSION"
-echo "APP_SHORT_NAME=$APP_SHORT_NAME" 
+echo "APP_SHORT_NAME=$APP_SHORT_NAME"
 export APP_SHORT_NAME="$APP_SHORT_NAME"
 
 ElectronArm64="https://github.com/unfoldingWord/electronite/releases/download/v37.1.0-graphite/electronite-v37.1.0-graphite-darwin-arm64.zip"
@@ -74,9 +83,9 @@ for ARCH in "x64" "arm64"; do
         echo "Skipping $ARCH build on $CPU_ARCH machine"
         continue
     fi
-  
+
     echo "Building for architecture: $ARCH"
-  
+
     downloadElectronUrl="$ElectronX64"
     expectedZip="*-x64-cli.zip"
     if [ "$ARCH" = "arm64" ]; then
@@ -84,32 +93,43 @@ for ARCH in "x64" "arm64"; do
         expectedZip="*-arm64-cli.zip"
     fi
 
-    cd ../install # required on local builds runs; no harm in gha
-    ./getElectronRelease.sh $downloadElectronUrl $ARCH $devRun
+    cd ../install || exit 1 # required on local builds runs; no harm in gha
 
-    if [ $? -ne 0 ]; then
-        echo "Error: Failed to get Electron release files at downloadElectronUrl - $?"
-        exit 1
-    fi
+    if [ "$fullInstall" = true ]; then
+        ./getElectronRelease.sh "$downloadElectronUrl" "$ARCH" "$devRun"
 
-    if [[ $devRun =~ ^(-d) ]]; then
-        pkgDir=viewer
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to get Electron release files at $downloadElectronUrl"
+            exit 1
+        fi
     else
-        pkgDir=temp
+        echo "Skipping Electron download/release step (not needed)."
     fi
 
-    # Run makeInstallElectronite Shell script
-    echo
-    echo "     ****************************************"
-    echo "     * Running makeInstallElectronite.sh... *"
-    echo "     * Wait for the prompt.                 *"
-    echo "     ****************************************"
-    echo
-    ./makeInstallElectronite.sh $ARCH $devRun
+    if [ "$devRun" = "-d" ]; then
+        pkgDir="viewer"
+    else
+        pkgDir="temp"
+    fi
 
-    if ! [[ $devRun =~ ^(-d) ]]; then
+    if [ "$fullInstall" = true ]; then
+        echo
+        echo "     ****************************************"
+        echo "     * Running makeInstallElectronite.sh... *"
+        echo "     * Wait for the prompt.                 *"
+        echo "     ****************************************"
+        echo
+    fi
+
+    if [ "$fullInstall" = true ]; then
+        ./makeInstallElectronite.sh "$ARCH" "$devRun" -f
+    else
+        ./makeInstallElectronite.sh "$ARCH" "$devRun"
+    fi
+
+    if [ "$devRun" != "-d" ]; then
         echo "Files at ../../releases/macos/"
-        ls -als ../../releases/macos/
+        ls -als "../../releases/macos/"
     fi
 
     if [ $? -ne 0 ]; then
@@ -121,9 +141,8 @@ done
 echo "Build completed for $CPU_ARCH architecture"
 
 # Remove temporary electronite files from local dev viewer build.
-if [[ $devRun =~ ^(-d) ]]; then
-    rm -rf ../$pkgDir/electron
-    rm -rf ../$pkgDir/electron.*
+if [ "$devRun" = "-d" ]; then
+    rm -rf "../$pkgDir/electron"
+    rm -rf "../$pkgDir/electron.*"
     echo "Local Dev Electronite Viewer has been successfully built."
 fi
-

--- a/macos/install/makeInstallElectronite.sh
+++ b/macos/install/makeInstallElectronite.sh
@@ -90,7 +90,7 @@ else
     pkgDir="temp"
 fi
 
-APP_BASE_DIR="../$pkgDir/project/payload/APP_NAME.app" # temp app foldername without spaces, will rename to actual name later
+APP_BASE_DIR="../$pkgDir/project/payload/${APP_NAME}.app" # temp app foldername without spaces, will rename to actual name later
 
 # Needed for local bundles. Not required in GHA but also doesn't hurt anything.
 if [ "$fullInstall" = true ] || [ "$devRun" != "-d" ]; then

--- a/macos/install/makeInstallElectronite.sh
+++ b/macos/install/makeInstallElectronite.sh
@@ -117,16 +117,13 @@ ELECTRON_DEST="${APP_BASE_DIR}/Contents/electron"
 NODE_MODULES_SRC="../../node_modules"
 NODE_MODULES_DEST="${ELECTRON_DEST}/node_modules"
 
-if [ "$fullInstall" = true ]; then
-    # copy shared electron files
-    cp -R "../../buildResources/electron" "${APP_BASE_DIR}/Contents/"
-    echo "Successfully copied shared electron files"
-else
-    echo "Skipping shared electron file copy (not needed)."
-    if [ ! -d "$ELECTRON_DEST" ]; then
-        echo "Error: Electron destination path not found for viewer update: $ELECTRON_DEST"
-        exit 1
-    fi
+# copy app-specific electron files
+cp -R "../../buildResources/electron/." "$ELECTRON_DEST/"
+echo "Successfully copied app-specific electron files"
+
+if [ ! -d "$ELECTRON_DEST" ]; then
+    echo "Error: Electron destination path not found for app-specific electron files: $ELECTRON_DEST"
+    exit 1
 fi
 
 cp "../../globalBuildResources/favicon"*.png "$ELECTRON_DEST"

--- a/macos/install/makeInstallElectronite.sh
+++ b/macos/install/makeInstallElectronite.sh
@@ -24,6 +24,7 @@
 #   $1 : Architecture type (Required)
 #        Accepted values: arm64, x64
 #   $2 : -d indicates a development run (for building viewer only)
+#   $3 : -f indicates full install including Electronite copy/download setup
 #
 # Returns:
 #   0 : Success
@@ -61,11 +62,18 @@ fi
 # get arguments
 arch="$1"
 devRun="${2:-no}" # This is a development viewer run if $1 is -d
+fullInstall=false
+
+for arg in "$@"; do
+    case "$arg" in
+        -f) fullInstall=true ;;
+    esac
+done
 
 # Needed for local bundles. Not required in GHA but does no harm.
-if ! [[ $devRun =~ ^(-d) ]]; then
+if [ "$devRun" != "-d" ]; then
   PKG_NAME="${FILE_APP_NAME}-${APP_VERSION}-macos-${arch}.pkg"
-  rm -f ../releases/macos/${FILE_APP_NAME}-*-macos-${arch}.pkg
+  rm -f "../releases/macos/${FILE_APP_NAME}-*-macos-${arch}.pkg"
 fi
 
 cd ../build || exit 1
@@ -76,62 +84,75 @@ cd ../build || exit 1
 # Turn on command echo
 # set -x
 
-if [[ $devRun =~ ^(-d) ]]; then
-        pkgDir=viewer
-    else
-        pkgDir=temp
-    fi
-
-# Needed for local bundles. Not required in GHA but also doesn't hurt anything.
-rm -rf ../$pkgDir/project
+if [ "$devRun" = "-d" ]; then
+    pkgDir="viewer"
+else
+    pkgDir="temp"
+fi
 
 APP_BASE_DIR="../$pkgDir/project/payload/APP_NAME.app" # temp app foldername without spaces, will rename to actual name later
 
-mkdir -p ${APP_BASE_DIR}/Contents/MacOS
+# Needed for local bundles. Not required in GHA but also doesn't hurt anything.
+if [ "$fullInstall" = true ] || [ "$devRun" != "-d" ]; then
+    rm -rf "../$pkgDir/project"
+fi
+
+mkdir -p "${APP_BASE_DIR}/Contents/MacOS"
 
 # Rocket config
-cp ../../Rocket.toml ${APP_BASE_DIR}/Rocket.toml
+cp "../../Rocket.toml" "${APP_BASE_DIR}/Rocket.toml"
 
 # electron startup
 LAUNCHER_NAME="start-${FILE_APP_NAME}.sh"
-cp ../buildResources/appLauncherElectron.sh ${APP_BASE_DIR}/Contents/MacOS/${LAUNCHER_NAME}
-sed -i.bak "s/\${APP_NAME}/$APP_NAME/g" ${APP_BASE_DIR}/Contents/MacOS/${LAUNCHER_NAME}
+cp "../buildResources/appLauncherElectron.sh" "${APP_BASE_DIR}/Contents/MacOS/${LAUNCHER_NAME}"
+sed -i.bak "s/\${APP_NAME}/$APP_NAME/g" "${APP_BASE_DIR}/Contents/MacOS/${LAUNCHER_NAME}"
 
 # find_free_port.sh, used by electron startup
-cp ../buildResources/find_free_port.sh ${APP_BASE_DIR}/Contents/MacOS/find_free_port.sh
+cp "../buildResources/find_free_port.sh" "${APP_BASE_DIR}/Contents/MacOS/find_free_port.sh"
 
 #remove backup
 rm "${APP_BASE_DIR}/Contents/MacOS/${LAUNCHER_NAME}.bak"
 
-# copy shared electron files
-cp -R ../../buildResources/electron ${APP_BASE_DIR}/Contents/
-cp ../../globalBuildResources/favicon*.png ${APP_BASE_DIR}/Contents/electron
-echo "Successfully copied electron files"
+ELECTRON_DEST="${APP_BASE_DIR}/Contents/electron"
+NODE_MODULES_SRC="../../node_modules"
+NODE_MODULES_DEST="${ELECTRON_DEST}/node_modules"
+
+if [ "$fullInstall" = true ]; then
+    # copy shared electron files
+    cp -R "../../buildResources/electron" "${APP_BASE_DIR}/Contents/"
+    echo "Successfully copied shared electron files"
+else
+    echo "Skipping shared electron file copy (not needed)."
+    if [ ! -d "$ELECTRON_DEST" ]; then
+        echo "Error: Electron destination path not found for viewer update: $ELECTRON_DEST"
+        exit 1
+    fi
+fi
+
+cp "../../globalBuildResources/favicon"*.png "$ELECTRON_DEST"
+echo "Copied favicon files"
 
 # Copy required node_modules and dependencies -- all OSes
-NODE_MODULES_SRC="../../node_modules"
-NODE_MODULES_DEST="${APP_BASE_DIR}/Contents/electron/node_modules"
+ALL_OS_MODULES="
+puppeteer-core
+@puppeteer/browsers
+chromium-bidi
+debug
+devtools-protocol
+ms
+typed-query-selector
+webdriver-bidi-protocol
+ws
+semver
+proxy-agent
+lru-cache
+agent-base
+proxy-from-env
+progress
+mitt
+"
 
-ALL_OS_MODULES=(
-    "puppeteer-core"
-    "@puppeteer/browsers"
-    "chromium-bidi"
-    "debug"
-    "devtools-protocol"
-    "ms"
-    "typed-query-selector"
-    "webdriver-bidi-protocol"
-    "ws"
-    "semver"
-    "proxy-agent"
-    "lru-cache"
-    "agent-base"
-    "proxy-from-env"
-    "progress"
-    "mitt"
-)
-
-for mod in "${ALL_OS_MODULES[@]}"; do
+for mod in $ALL_OS_MODULES; do
     mkdir -p "${NODE_MODULES_DEST}/${mod}"
     cp -R "${NODE_MODULES_SRC}/${mod}/." "${NODE_MODULES_DEST}/${mod}/"
 done
@@ -139,25 +160,29 @@ done
 echo "Successfully copied node_modules dependencies"
 
 # Replace all occurrences of ${APP_NAME} and ${APP_VERSION} in startup script
-sed -i.bak "s/\${APP_NAME}/$APP_NAME/g" "${APP_BASE_DIR}/Contents/electron/electronStartup.js"  # Replace all occurrences of ${APP_NAME}
-sed -i.bak "s/\${APP_NAME}/$APP_NAME/g" "${APP_BASE_DIR}/Contents/electron/package.json"  # Replace all occurrences of ${APP_NAME}
-sed -i.bak "s/\${APP_VERSION}/$APP_VERSION/g" "${APP_BASE_DIR}/Contents/electron/package.json"  # Replace all occurrences of ${APP_VERSION}
+sed -i.bak "s/\${APP_NAME}/$APP_NAME/g" "${ELECTRON_DEST}/electronStartup.js"  # Replace all occurrences of ${APP_NAME}
+sed -i.bak "s/\${APP_NAME}/$APP_NAME/g" "${ELECTRON_DEST}/package.json"  # Replace all occurrences of ${APP_NAME}
+sed -i.bak "s/\${APP_VERSION}/$APP_VERSION/g" "${ELECTRON_DEST}/package.json"  # Replace all occurrences of ${APP_VERSION}
 
 # now copy architecture specific electron files
-cp -R ../$pkgDir/electron.$arch/* ${APP_BASE_DIR}/Contents/electron
+if [ "$fullInstall" = true ]; then
+    cp -R "../$pkgDir/electron.$arch/"* "$ELECTRON_DEST"
+else
+    echo "Skipping architecture-specific electron file copy (not needed)."
+fi
 
 # Check if Electron executable owner is current user
-ELECTRON_OWNER=$(stat -f %u ${APP_BASE_DIR}/Contents/electron/Electron.app/Contents/MacOS/Electron)
+ELECTRON_OWNER=$(stat -f %u "${APP_BASE_DIR}/Contents/electron/Electron.app/Contents/MacOS/Electron")
 CURRENT_USER=$(id -u)
 if [ "$ELECTRON_OWNER" != "$CURRENT_USER" ]; then
     echo "Error: Electron executable owner is not current user. Please run: sudo chown -R $(id -u):$(id -g) ../buildResources/electron.$arch/*"
     exit 1
 fi
 
-# rename Electron.app folder 
-mv ${APP_BASE_DIR}/Contents/electron/Electron.app ${APP_BASE_DIR}/Contents/electron/Electron
+# rename Electron.app folder
+mv "${APP_BASE_DIR}/Contents/electron/Electron.app" "${APP_BASE_DIR}/Contents/electron/Electron"
 
-chmod 755 ${APP_BASE_DIR}/Contents/electron/Electron/Contents/MacOS/Electron
+chmod 755 "${APP_BASE_DIR}/Contents/electron/Electron/Contents/MacOS/Electron"
 
 # update Info.plist file in Electron folder - insert app name
 echo "Updating Electron Info.plist file"
@@ -168,12 +193,12 @@ sed -i.bak "/CFBundleName/{n;s/Electron/$APP_NAME/g;}" "$PLIST_FILE_ELECTRON"
 cat "$PLIST_FILE_ELECTRON"
 echo "Done Updating Electron Info.plist file"
 
-if ! [[ $devRun =~ ^(-d) ]]; then
-  mkdir -p ${APP_BASE_DIR}/Contents/Resources
-  cp ../../globalBuildResources/icon.icns ${APP_BASE_DIR}/Contents/Resources/icon.icns
+if [ "$devRun" != "-d" ]; then
+  mkdir -p "${APP_BASE_DIR}/Contents/Resources"
+  cp "../../globalBuildResources/icon.icns" "${APP_BASE_DIR}/Contents/Resources/icon.icns"
 
   # copy Info.plist
-  cp ../buildResources/Info.plist ${APP_BASE_DIR}/Contents/
+  cp "../buildResources/Info.plist" "${APP_BASE_DIR}/Contents/"
   PLIST_FILE="${APP_BASE_DIR}/Contents/Info.plist"
 
   # Check if the file exists
@@ -198,39 +223,39 @@ if ! [[ $devRun =~ ^(-d) ]]; then
   echo "New  plist file:"
   cat "$PLIST_FILE"
 
-  cp -R ./bin ${APP_BASE_DIR}/Contents/
+  cp -R "./bin" "${APP_BASE_DIR}/Contents/"
   echo "copied bin to $APP_BASE_DIR/Contents/"
-  chmod 755 ${APP_BASE_DIR}/Contents/bin/server.bin
-  chmod 755 ${APP_BASE_DIR}/Contents/MacOS/${LAUNCHER_NAME}
-  chmod 755 ${APP_BASE_DIR}/Contents/MacOS/find_free_port.sh
+  chmod 755 "${APP_BASE_DIR}/Contents/bin/server.bin"
+  chmod 755 "${APP_BASE_DIR}/Contents/MacOS/${LAUNCHER_NAME}"
+  chmod 755 "${APP_BASE_DIR}/Contents/MacOS/find_free_port.sh"
 
-  cp -R ./lib ${APP_BASE_DIR}/Contents/
+  cp -R "./lib" "${APP_BASE_DIR}/Contents/"
   echo "copied lib to $APP_BASE_DIR/Contents/"
 
   SCRIPTS_DIR="../$pkgDir/project/scripts"
-  mkdir -p $SCRIPTS_DIR
+  mkdir -p "$SCRIPTS_DIR"
   PREINST_FILE="../$pkgDir/project/scripts/preinstall"
-  cp ../buildResources/preinstall "$PREINST_FILE"
+  cp "../buildResources/preinstall" "$PREINST_FILE"
   echo "copied preinstall to $SCRIPTS_DIR"
   sed -i.bak "s/{APP_SHORT_NAME}/$APP_SHORT_NAME/g" "$PREINST_FILE"
   echo "Replaced {APP_SHORT_NAME} with \"$APP_SHORT_NAME\" in $PREINST_FILE."
   chmod +x "$PREINST_FILE"
   POSTINST_FILE="../$pkgDir/project/scripts/postinstall"
-  cp ../build/post_install_script.sh $POSTINST_FILE
+  cp "../build/post_install_script.sh" "$POSTINST_FILE"
   echo "copied post_install_script.sh to $SCRIPTS_DIR"
   echo "Variables in post_install_script.sh were already replaced by: node build.js"
-  chmod +x $POSTINST_FILE
+  chmod +x "$POSTINST_FILE"
 fi
 
 # set execute permission on all folders
-find ${APP_BASE_DIR}/ -type d -exec chmod u+x,g+x,o+x {} +
+find "${APP_BASE_DIR}/" -type d -exec chmod u+x,g+x,o+x {} +
 
 # rename to final app name
-mv ${APP_BASE_DIR} "$(dirname "${APP_BASE_DIR}")/${APP_NAME}.app"
+mv "${APP_BASE_DIR}" "$(dirname "${APP_BASE_DIR}")/${APP_NAME}.app"
 
-if ! [[ $devRun =~ ^(-d) ]]; then
+if [ "$devRun" != "-d" ]; then
   # maintain a one-off identifier for simpler upgrades of early test releases
-  if [ "$FILE_APP_NAME" == "liminal" ]; then
+  if [ "$FILE_APP_NAME" = "liminal" ]; then
     IDENTIFIER="com.yourdomain.liminal"
   else
     IDENTIFIER="pankosmia.${FILE_APP_NAME}"
@@ -239,13 +264,13 @@ if ! [[ $devRun =~ ^(-d) ]]; then
   # build pkg
   cd ..
   pkgbuild \
-    --root ./$pkgDir/project/payload \
-    --scripts ./$pkgDir/project/scripts \
-    --identifier ${IDENTIFIER} \
+    --root "./$pkgDir/project/payload" \
+    --scripts "./$pkgDir/project/scripts" \
+    --identifier "${IDENTIFIER}" \
     --version "$APP_VERSION" \
     --install-location /Applications \
-    ./build/${PKG_NAME}
+    "./build/${PKG_NAME}"
 
   # copy to releases folder
-  cp ./build/${PKG_NAME} ../releases/macos/
+  cp "./build/${PKG_NAME}" "../releases/macos/"
 fi

--- a/macos/scripts/build_viewer.zsh
+++ b/macos/scripts/build_viewer.zsh
@@ -1,45 +1,52 @@
 #!/usr/bin/env zsh
 
-# Run from pankosmia\[this-repo's-name]\macos\scripts directory by:  .\build_viewer.zsh
+# Run from pankosmia\[this-repo's-name]\macos\scripts directory by:  ./build_viewer.zsh
+# Or force a full install with: ./build_viewer.zsh -f
 
 source ../../app_config.env
+
+FORCE_FULL_INSTALL=false
+if [[ "${1:-}" == "-f" ]]; then
+    FORCE_FULL_INSTALL=true
+fi
 
 ELECTRON_VER="../viewer/project/payload/${APP_NAME}.app/Contents/electron/version"
 EXPECTED="37.1.0"
 
 # A full install will also install, or re-install, Electronite.
-fullInstall=false
+fullInstall=$FORCE_FULL_INSTALL
 
-if [ -f "$ELECTRON_VER" ]; then
-    content="$(tr -d '\r\n' < "$ELECTRON_VER")"
-    if [ "$content" = "$EXPECTED" ]; then
-        echo "The installed viewer Electronite version is $content, which is correct."
-        echo "No download is needed. Everything else will be updated."
-        fullInstall=false
+if [ "$fullInstall" != true ]; then
+    if [ -f "$ELECTRON_VER" ]; then
+        content="$(tr -d '\r\n' < "$ELECTRON_VER")"
+        if [ "$content" = "$EXPECTED" ]; then
+            echo "The installed viewer Electronite version is $content, which is correct."
+            echo "No download is needed. Everything else will be updated."
+            fullInstall=false
+        else
+            echo "The installed viewer Electronite version is $content, however we are not using $EXPECTED. Please wait for the download and upgrade that will follow..."
+            fullInstall=true
+        fi
     else
-        echo "The installed viewer Electronite version is $content, however we are not using $EXPECTED. Please wait for the download and upgrade that will follow..."
+        echo "A full viewer install will follow, including download of Electronite. Please wait patiently..."
         fullInstall=true
     fi
 else
+    echo "-f flag detected."
     echo "A full viewer install will follow, including download of Electronite. Please wait patiently..."
-    fullInstall=true
 fi
 
 TEMP_DIR="../viewer"
 if [ "$fullInstall" = true ] && [ -d "$TEMP_DIR" ]; then
     echo "Deleting previous viewer build..."
-    echo
     rm -rf "$TEMP_DIR"
 fi
 
 if [ "$fullInstall" = true ]; then
-    echo
-    echo
     echo "********************************************************************"
     echo "\"Getting Electron release\" downloads an approximately 120 MB file."
     echo "Please wait patiently for the download process to complete..."
     echo "********************************************************************"
-    echo
     ../install/makeAllInstallsElectronite.sh -d -f
 else
     ../install/makeAllInstallsElectronite.sh -d

--- a/macos/scripts/build_viewer.zsh
+++ b/macos/scripts/build_viewer.zsh
@@ -2,19 +2,43 @@
 
 # Run from pankosmia\[this-repo's-name]\macos\scripts directory by:  .\build_viewer.zsh
 
-TEMP_DIR=../viewer
-if [ -d $TEMP_DIR ]; then
-    echo "Deleting previous viewer build..."
-    echo
-    rm -rf $TEMP_DIR
+ELECTRON_VER="../viewer/project/payload/APP_NAME.app/Contents/electron/version"
+EXPECTED="37.1.0"
+
+# A full install will also install, or re-install, Electronite.
+fullInstall=false
+
+if [ -f "$ELECTRON_VER" ]; then
+    content="$(tr -d '\r\n' < "$ELECTRON_VER")"
+    if [ "$content" = "$EXPECTED" ]; then
+        echo "The installed viewer Electronite version is $content, which is correct."
+        echo "No download is needed. Everything else will be updated."
+        fullInstall=false
+    else
+        echo "The installed viewer Electronite version is $content, however we are not using $EXPECTED. Please wait for the download and upgrade that will follow..."
+        fullInstall=true
+    fi
+else
+    echo "A full viewer install will follow, including download of Electronite. Please wait patiently..."
+    fullInstall=true
 fi
 
-echo
-echo
-echo "********************************************************************"
-echo "\"Getting Electron release\" downloads an approximately 120 MB file."
-echo "Please wait patiently for the download process to complete..."
-echo "********************************************************************"
-echo
+TEMP_DIR="../viewer"
+if [ "$fullInstall" = true ] && [ -d "$TEMP_DIR" ]; then
+    echo "Deleting previous viewer build..."
+    echo
+    rm -rf "$TEMP_DIR"
+fi
 
-../install/makeAllInstallsElectronite.sh -d
+if [ "$fullInstall" = true ]; then
+    echo
+    echo
+    echo "********************************************************************"
+    echo "\"Getting Electron release\" downloads an approximately 120 MB file."
+    echo "Please wait patiently for the download process to complete..."
+    echo "********************************************************************"
+    echo
+    ../install/makeAllInstallsElectronite.sh -d -f
+else
+    ../install/makeAllInstallsElectronite.sh -d
+fi

--- a/macos/scripts/build_viewer.zsh
+++ b/macos/scripts/build_viewer.zsh
@@ -2,7 +2,9 @@
 
 # Run from pankosmia\[this-repo's-name]\macos\scripts directory by:  .\build_viewer.zsh
 
-ELECTRON_VER="../viewer/project/payload/APP_NAME.app/Contents/electron/version"
+source ../../app_config.env
+
+ELECTRON_VER="../viewer/project/payload/${APP_NAME}.app/Contents/electron/version"
 EXPECTED="37.1.0"
 
 # A full install will also install, or re-install, Electronite.

--- a/macos/scripts/bundle_viewer.zsh
+++ b/macos/scripts/bundle_viewer.zsh
@@ -58,4 +58,4 @@ echo "Please wait patiently for the download process to complete..."
 echo "********************************************************************"
 echo
 
-../install/makeAllInstallsElectronite.sh
+../install/makeAllInstallsElectronite.sh -f

--- a/windows/install/makeAllInstallsElectronite.ps1
+++ b/windows/install/makeAllInstallsElectronite.ps1
@@ -14,17 +14,22 @@
     - getElectronRelease.ps1
     - makeInstallElectronite.ps1
 
+.PARAMETER Dev
+    Specify -Dev "Y" when generating a development viewer.
+    - Default is "N"
+
 .PARAMETER IsGHA
     Specify -IsGHA "N" when run locally to avoid a failed attempt to list github actions environment variables.
     - Default is "Y"
 
-.PARAMETER Dev
-    Specify -Dev "Y" when generating a development viewer.
-    - Default is "N"
+.PARAMETER FullInstall
+    Specify -FullInstall $true for installing Electronite too; -FullInstall $false for updating all but Electronite (e.g., a development environment viewer update)
+    - Default is $true
 #>
 param(
-    [string]$Dev,
-    [string]$IsGHA
+    [string]$Dev = "N",
+    [string]$IsGHA = "Y",
+    [bool]$FullInstall = $true
 )
 
 # get environment variables from app_config.env
@@ -61,10 +66,10 @@ $CPU_ARCH = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitect
 foreach ($ARCH in @("x64", "arm64")) {
     # Skip if not running on native architecture
     if ($ARCH -ne $CPU_ARCH) {
-        Write-Host "Skipping $ARCH build on $CPU_ARCH machine"
+        Write-Host "Skipping $ARCH build on $CPU_ARCH machine (not applicable)."
         continue
     }
-    Write-Host "Building for architecture: $ARCH"
+    Write-Host "Architecture: $ARCH"
 
     # Set download URLs based on architecture
     $downloadElectronUrl = $ElectronX64
@@ -76,11 +81,16 @@ foreach ($ARCH in @("x64", "arm64")) {
     }
 
     # Get Electron release
-    Write-Host "Getting Electron release..."
-    $electronResult = & "$PSScriptRoot\getElectronRelease.ps1" -downloadUrl $downloadElectronUrl -arch $ARCH -Dev $Dev
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "Error: Failed to get Electron release files at $downloadElectronUrl"
-        exit 1
+    if ($FullInstall) {
+        # Get Electron release
+        Write-Host "Getting Electron release..."
+        $electronResult = & "$PSScriptRoot\getElectronRelease.ps1" -downloadUrl $downloadElectronUrl -arch $ARCH -Dev $Dev
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Error: Failed to get Electron release files at $downloadElectronUrl"
+            exit 1
+        }
+    } else {
+        Write-Host "Skipping Electron download/release step (not needed)."
     }
 
     if ($Dev -ne 'Y') {
@@ -92,12 +102,14 @@ foreach ($ARCH in @("x64", "arm64")) {
     }
 
     # Run makeInstallElectronite PowerShell script
-    Write-Host "`n"
-    Write-Host "     *****************************************"
-    Write-Host "     * Running makeInstallElectronite.ps1... *"
-    Write-Host "     * Wait for the prompt.                  *"
-    Write-Host "     *****************************************"
-    Write-Host "`n"
+    if ($FullInstall) {
+        Write-Host "`n"
+        Write-Host "     *****************************************"
+        Write-Host "     * Running makeInstallElectronite.ps1... *"
+        Write-Host "     * Wait for the prompt.                  *"
+        Write-Host "     *****************************************"
+        Write-Host "`n"
+    }
     $makeInstallElectronitePath = Join-Path $PSScriptRoot "makeInstallElectronite.ps1"
     if (-not (Test-Path $makeInstallElectronitePath)) {
         Write-Host "Error: makeInstallElectronite.ps1 not found at $makeInstallElectronitePath"
@@ -105,9 +117,9 @@ foreach ($ARCH in @("x64", "arm64")) {
     }
 
     if ($Dev -eq 'Y') {
-      $result = & "$makeInstallElectronitePath" -Dev $Dev -arch $arch
+      $result = & "$makeInstallElectronitePath" -Dev $Dev -arch $arch -FullInstall $FullInstall
     } else {
-      $result = & "$makeInstallElectronitePath" -arch $arch
+      $result = & "$makeInstallElectronitePath" -arch $arch -FullInstall $FullInstall
     }
     if ($LASTEXITCODE -ne 0) {
         Write-Host "Error: makeInstallElectronite.ps1 failed with exit code $LASTEXITCODE"

--- a/windows/install/makeInstallElectronite.ps1
+++ b/windows/install/makeInstallElectronite.ps1
@@ -149,6 +149,11 @@ try {
             exit 1
         }
 
+        # Explicitly create electron destination directory if not found 
+        if (-not (Test-Path $electronDestPath)) {
+            New-Item -ItemType Directory -Path $electronDestPath -Force | Out-Null
+        }
+
         # Copy all app-specific electron files
         Copy-Item -Path $electronSrcPath -Destination $electronDestPath -Recurse -Force -ErrorAction Stop
         Write-Host "Successfully copied app-specific electron files"
@@ -165,6 +170,11 @@ try {
         # Copy required modules and dependencies
         $nodeModulesSrc = Join-Path $PSScriptRoot "..\..\node_modules"
         $nodeModulesDest = Join-Path $electronDestPath "node_modules"
+
+        # Explicitly create node_modules if not found
+        if (-not (Test-Path $nodeModulesDest)) {
+            New-Item -ItemType Directory -Path $nodeModulesDest -Force | Out-Null
+        }
 
         # 7zip-min (full directory) -- Windows only
         $7zipMinDest = Join-Path $nodeModulesDest "7zip-min"

--- a/windows/install/makeInstallElectronite.ps1
+++ b/windows/install/makeInstallElectronite.ps1
@@ -38,10 +38,8 @@ param(
     [Parameter(Mandatory=$true)]
     [string]$arch,
 
-    [Parameter(Mandatory=$false)]
     [string]$Dev = "N",
 
-    [Parameter(Mandatory=$true)]
     [bool]$FullInstall = $true
 )
 

--- a/windows/install/makeInstallElectronite.ps1
+++ b/windows/install/makeInstallElectronite.ps1
@@ -28,6 +28,10 @@ Target architecture for the installer (e.g., x64, arm64, x86)
 .PARAMETER Dev
 Specify -Dev "Y" when generating a development viewer.
 - Default is "N"
+
+.PARAMETER FullInstall
+    Specify -FullInstall $true for installing Electronite too; -FullInstall $false for updating all but Electronite (e.g., a development environment viewer update)
+    - Default is $true
 #>
 
 param(
@@ -35,7 +39,10 @@ param(
     [string]$arch,
 
     [Parameter(Mandatory=$false)]
-    [string]$Dev
+    [string]$Dev = "N",
+
+    [Parameter(Mandatory=$true)]
+    [bool]$FullInstall = $true
 )
 
 # Save the initial working directory
@@ -85,7 +92,9 @@ try {
     Set-Location -Path "..\build" -ErrorAction Stop
 
     # Create folder structure for package
-    Write-Host "Building folder structure for package..."
+    if ($FullInstall) {
+      Write-Host "Building folder structure for package..."
+    }
 
     if ($Dev -eq 'Y') {
       $pkgDir = "viewer"
@@ -94,9 +103,12 @@ try {
     }
 
     # Clean up and create project directories -- Needed for local bundles; Not required in GHA but also doesn't hurt anything.
-    Remove-Item -Path "..\$pkgDir\project" -Recurse -Force -ErrorAction SilentlyContinue
     $projectPath = "..\$pkgDir\project"
     $payloadPath = Join-Path $projectPath "payload\app"
+
+    if ($FullInstall -or $Dev -ne 'Y') {
+        Remove-Item -Path $projectPath -Recurse -Force -ErrorAction SilentlyContinue
+    }
 
     New-Item -ItemType Directory -Force -Path $payloadPath | Out-Null
 
@@ -113,36 +125,48 @@ try {
     }
 
     # Copy electron files
-    Write-Host "Copying Electron files..."
+    if ($FullInstall) {
+      Write-Host "Preparing Electron files..."
+    } else {
+      Write-Host "Preparing viewer update..."
+    }
     try {
-        # Copy all the general electron files
         $electronSrcPath = Join-Path $PSScriptRoot "..\..\buildResources\electron"
         $electronDestPath = Join-Path $payloadPath "electron"
-        $electronDestPath = Join-Path $payloadPath "electron"
 
-        Write-Host "Electron source path: $electronSrcPath" -ErrorAction SilentlyContinue
-        Write-Host "Electron destination path: $electronDestPath" -ErrorAction SilentlyContinue
-
-        # Ensure source exists
-        if (-not (Test-Path $electronSrcPath)) {
-            Write-Error "Source path not found: $electronSrcPath"
-            exit 1
+        if ($FullInstall) {
+          Write-Host "Electron source path: $electronSrcPath" -ErrorAction SilentlyContinue
+          Write-Host "Electron destination path: $electronDestPath" -ErrorAction SilentlyContinue
         }
-        
+
         # Ensure destination parent exists
         $destParent = Split-Path -Parent $electronDestPath
         if (-not (Test-Path $destParent)) {
             New-Item -ItemType Directory -Path $destParent -Force | Out-Null
         }
 
-        # Copy main electron files
-        Copy-Item -Path $electronSrcPath -Destination $electronDestPath -Recurse -Force -ErrorAction Stop
-        Write-Host "Successfully copied electron files"
+        if ($FullInstall) {
+            # Ensure source exists
+            if (-not (Test-Path $electronSrcPath)) {
+                Write-Error "Source path not found: $electronSrcPath"
+                exit 1
+            }
+
+            # Copy all the general electron files
+            Copy-Item -Path $electronSrcPath -Destination $electronDestPath -Recurse -Force -ErrorAction Stop
+            Write-Host "Successfully copied general electron files"
+        } else {
+            Write-Host "Skipping general electron file copy (not needed)."
+            if (-not (Test-Path $electronDestPath)) {
+                Write-Error "Electron destination path not found for partial install: $electronDestPath"
+                exit 1
+            }
+        }
 
         # Copy main electron browser window icon
         $electronIconSrc = Join-Path $PSScriptRoot "..\..\globalBuildResources\favicon*.png"
         Write-Host "Copying favicon*.png to $electronDestPath ..."
-        Copy-Item $electronIconSrc -Destination $electronDestPath
+        Copy-Item $electronIconSrc -Destination $electronDestPath -Force
 
         # Copy required modules and dependencies
         $nodeModulesSrc = Join-Path $PSScriptRoot "..\..\node_modules"
@@ -171,13 +195,13 @@ try {
             "ms",
             "typed-query-selector",
             "webdriver-bidi-protocol",
-            "ws"
-            "semver"
-            "proxy-agent"
-            "lru-cache"
-            "agent-base"
-            "proxy-from-env"
-            "progress"
+            "ws",
+            "semver",
+            "proxy-agent",
+            "lru-cache",
+            "agent-base",
+            "proxy-from-env",
+            "progress",
             "mitt"
         )
 
@@ -188,24 +212,28 @@ try {
         }
 
         Write-Host "Successfully copied node_modules dependencies"
-        
-        # Replace all occurrences of ${APP_NAME} and ${APP_VERSION} in startup script
-        (Get-Content $electronDestPath\electronStartup.js).Replace('${APP_NAME}', $env:APP_NAME) | Set-Content $electronDestPath\electronStartup.js
-        (Get-Content "$electronDestPath\package.json").Replace('${APP_NAME}', $env:APP_NAME).Replace('${APP_VERSION}', $env:APP_VERSION) | Set-Content "$electronDestPath\package.json"
-        
-        # Copy architecture-specific files
-        $archElectronPath = Join-Path $PSScriptRoot "..\$pkgDir\electron.$arch"
-        Write-Host "Electron arch path: $archElectronPath" -ErrorAction SilentlyContinue
 
-        if (Test-Path $archElectronPath) {
-            Copy-Item -Path "$archElectronPath\*" -Destination $electronDestPath -Recurse -Force -ErrorAction Stop
-            Write-Host "Successfully copied architecture-specific files"
+        # Replace all occurrences of ${APP_NAME} and ${APP_VERSION} in startup script
+        (Get-Content "$electronDestPath\electronStartup.js").Replace('${APP_NAME}', $env:APP_NAME) | Set-Content "$electronDestPath\electronStartup.js"
+        (Get-Content "$electronDestPath\package.json").Replace('${APP_NAME}', $env:APP_NAME).Replace('${APP_VERSION}', $env:APP_VERSION) | Set-Content "$electronDestPath\package.json"
+
+        if ($FullInstall) {
+            # Copy architecture-specific files
+            $archElectronPath = Join-Path $PSScriptRoot "..\$pkgDir\electron.$arch"
+            Write-Host "Electron arch path: $archElectronPath" -ErrorAction SilentlyContinue
+
+            if (Test-Path $archElectronPath) {
+                Copy-Item -Path "$archElectronPath\*" -Destination $electronDestPath -Recurse -Force -ErrorAction Stop
+                Write-Host "Successfully copied architecture-specific files"
+            } else {
+                Write-Warning "Architecture-specific path not found: $archElectronPath"
+            }
         } else {
-            Write-Warning "Architecture-specific path not found: $archElectronPath"
+            Write-Host "Skipping architecture-specific electron file copy (not needed)."
         }
     }
     catch {
-        Write-Error "Failed to copy electron files: $_"
+        Write-Error "Failed to prepare electron files: $_"
         exit 1
     }
 

--- a/windows/install/makeInstallElectronite.ps1
+++ b/windows/install/makeInstallElectronite.ps1
@@ -158,7 +158,7 @@ try {
         } else {
             Write-Host "Skipping general electron file copy (not needed)."
             if (-not (Test-Path $electronDestPath)) {
-                Write-Error "Electron destination path not found for partial install: $electronDestPath"
+                Write-Error "Electron destination path not found for viewer update: $electronDestPath"
                 exit 1
             }
         }

--- a/windows/install/makeInstallElectronite.ps1
+++ b/windows/install/makeInstallElectronite.ps1
@@ -131,7 +131,7 @@ try {
       Write-Host "Preparing viewer update..."
     }
     try {
-        $electronSrcPath = Join-Path $PSScriptRoot "..\..\buildResources\electron"
+        $electronSrcPath = Join-Path $PSScriptRoot "..\..\buildResources\electron\*"
         $electronDestPath = Join-Path $payloadPath "electron"
 
         if ($FullInstall) {
@@ -145,22 +145,18 @@ try {
             New-Item -ItemType Directory -Path $destParent -Force | Out-Null
         }
 
-        if ($FullInstall) {
-            # Ensure source exists
-            if (-not (Test-Path $electronSrcPath)) {
-                Write-Error "Source path not found: $electronSrcPath"
-                exit 1
-            }
+        # Ensure source exists
+        if (-not (Test-Path $electronSrcPath)) {
+            Write-Error "Source path not found: $electronSrcPath"
+            exit 1
+        }
 
-            # Copy all the general electron files
-            Copy-Item -Path $electronSrcPath -Destination $electronDestPath -Recurse -Force -ErrorAction Stop
-            Write-Host "Successfully copied general electron files"
-        } else {
-            Write-Host "Skipping general electron file copy (not needed)."
-            if (-not (Test-Path $electronDestPath)) {
-                Write-Error "Electron destination path not found for viewer update: $electronDestPath"
-                exit 1
-            }
+        # Copy all app-specific electron files
+        Copy-Item -Path $electronSrcPath -Destination $electronDestPath -Recurse -Force -ErrorAction Stop
+        Write-Host "Successfully copied app-specific electron files"
+        if (-not (Test-Path $electronDestPath)) {
+            Write-Error "Electron destination path not found for app-specific files: $electronDestPath"
+            exit 1
         }
 
         # Copy main electron browser window icon

--- a/windows/scripts/build_viewer.ps1
+++ b/windows/scripts/build_viewer.ps1
@@ -1,39 +1,47 @@
 # Run from pankosmia\[this-repo's-name]\windows\scripts directory in powershell by:  .\build_viewer.ps1
+# Or force a full install with: .\build_viewer.ps1 -f
+
+param(
+    [switch]$f
+)
 
 $ELECTRON_VER = "..\viewer\project\payload\app\electron\version"
 
 $expected = '37.1.0'
-if (Test-Path -LiteralPath $ELECTRON_VER -PathType Leaf) {
-    $content = Get-Content -LiteralPath $ELECTRON_VER -Raw
-    if ($content -eq $expected) {
-        Write-Host 'The installed viewer Electronite version is'$content', which is correct.'
-        Write-Host 'No download is needed. Everything else will be updated.'
-        $installElectron = $false
-    } else {
-        Write-Host 'The installed viewer Electronite version is '$content', however we are not using '$expected'. Please wait for the download and upgrade that will follow...'
+$installElectron = $f.IsPresent
+
+if (-not $installElectron) {
+    if (Test-Path -LiteralPath $ELECTRON_VER -PathType Leaf) {
+        $content = Get-Content -LiteralPath $ELECTRON_VER -Raw
+        if ($content -eq $expected) {
+            Write-Host 'The installed viewer Electronite version is'$content', which is correct.'
+            Write-Host 'No download is needed. Everything else will be updated.'
+            $installElectron = $false
+        } else {
+            Write-Host 'The installed viewer Electronite version is '$content', however we are not using '$expected'. Please wait for the download and upgrade that will follow...'
+            $installElectron = $true
+        }
+    }
+    else {
+        'A full viewer install will follow, including download of Electronite. Please wait patiently...'
         $installElectron = $true
     }
-}
-else {
-    'A full viewer install will follow, including download of Electronite.  Please wait patiently...'
-    $installElectron = $true
+} else {
+    Write-Host '-f flag detected.'
+    Write-Host 'A full viewer install will follow, including download of Electronite. Please wait patiently...'
 }
 
 $TEMP_DIR = "..\viewer"
-    if ($installElectron -and (Test-Path $TEMP_DIR)) {
-        Write-Host "Deleting previous viewer build..."
-        Write-Host "`n"
-        Remove-Item -Path $TEMP_DIR -Recurse -Force
-    }
+if ($installElectron -and (Test-Path $TEMP_DIR)) {
+    Write-Host "Deleting previous viewer build..."
+    Remove-Item -Path $TEMP_DIR -Recurse -Force
+}
 
 if ($installElectron) {
-    Write-Host "`n"
-    Write-Host "`n"
     Write-Host "*************************************************************************" -f cyan;
     Write-Host "`"Getting Electron release`" downloads an approximately 120 MB file." -f cyan;
     Write-Host "Please wait patiently for the highlighted download process to complete..." -f cyan;
     Write-Host "*************************************************************************" -f cyan;
-    Write-Host "`n"
 }
 
 ..\install\makeAllInstallsElectronite.ps1 -Dev "Y" -IsGHA "N" -FullInstall $installElectron

--- a/windows/scripts/build_viewer.ps1
+++ b/windows/scripts/build_viewer.ps1
@@ -1,18 +1,39 @@
 # Run from pankosmia\[this-repo's-name]\windows\scripts directory in powershell by:  .\build_viewer.ps1
 
+$ELECTRON_VER = "..\viewer\project\payload\app\electron\version"
+
+$expected = '37.1.0'
+if (Test-Path -LiteralPath $ELECTRON_VER -PathType Leaf) {
+    $content = Get-Content -LiteralPath $ELECTRON_VER -Raw
+    if ($content -eq $expected) {
+        Write-Host 'The installed viewer Electronite version is'$content', which is correct.'
+        Write-Host 'No download is needed. Everything else will be updated.'
+        $installElectron = $false
+    } else {
+        Write-Host 'The installed viewer Electronite version is '$content', however we are not using '$expected'. Please wait for the download and upgrade that will follow...'
+        $installElectron = $true
+    }
+}
+else {
+    'A full viewer install will follow, including download of Electronite.  Please wait patiently...'
+    $installElectron = $true
+}
+
 $TEMP_DIR = "..\viewer"
-  if (Test-Path $TEMP_DIR) {
-      Write-Host "Deleting previous viewer build..."
-      Write-Host "`n"
-      Remove-Item -Path $TEMP_DIR -Recurse -Force
-  }
+    if ($installElectron -and (Test-Path $TEMP_DIR)) {
+        Write-Host "Deleting previous viewer build..."
+        Write-Host "`n"
+        Remove-Item -Path $TEMP_DIR -Recurse -Force
+    }
 
-Write-Host "`n"
-Write-Host "`n"
-Write-Host "*************************************************************************" -f cyan;
-Write-Host "`"Getting Electron release`" downloads an approximately 120 MB file." -f cyan;
-Write-Host "Please wait patiently for the highlighted download process to complete..." -f cyan;
-Write-Host "*************************************************************************" -f cyan;
-Write-Host "`n"
+if ($installElectron) {
+    Write-Host "`n"
+    Write-Host "`n"
+    Write-Host "*************************************************************************" -f cyan;
+    Write-Host "`"Getting Electron release`" downloads an approximately 120 MB file." -f cyan;
+    Write-Host "Please wait patiently for the highlighted download process to complete..." -f cyan;
+    Write-Host "*************************************************************************" -f cyan;
+    Write-Host "`n"
+}
 
-..\install\makeAllInstallsElectronite.ps1 -Dev "Y" -IsGHA "N"
+..\install\makeAllInstallsElectronite.ps1 -Dev "Y" -IsGHA "N" -FullInstall $installElectron


### PR DESCRIPTION
@gabrielaillet first brought up the need for this when he was testing puppeteer and keep needing to rebuild the viewer to run his tests.  A full viewer build is painfully slow on Windows, less so on Linux though still irksome especially when repeat builds are in play, and quite fast on Mac Arm in which development happens the least...

This PR:
- Checks the Electronite version the viewer has already been built.
  - If the version is correct, then the download and Electron install steps are skipped. (e.g., a viewer update)
- Only runs a full install of the viewer when it does not yet exist or when the version is out of date.

| Test Grid | build_viewer when there is none (full install) | re-run build_viewer when the Electronite version is correct (e.g., rebuild). Test with a change. | re-run build_viewer when the Eletronite version is outdated (full install) | bundle_viewer in local development environment | <pre>-f</pre> | GHA workflow run | [GHA Artifacts](https://github.com/pankosmia/desktop-app-template/actions/runs/32307423467) |
|---|---|---|---|---|---|--|--|
| Windows x64 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| Linux x64 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| MacOS Arm64 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
